### PR TITLE
[Client] Show horizontal art for cards in the profile banner and playmats

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -166,6 +166,7 @@ set(cockatrice_SOURCES
     src/interface/widgets/cards/additional_info/mana_cost_widget.cpp
     src/interface/widgets/cards/additional_info/mana_symbol_widget.cpp
     src/interface/widgets/cards/art_crop_attribution.cpp
+    src/interface/widgets/cards/card_art_utils.cpp
     src/interface/widgets/cards/card_group_display_widgets/card_group_display_widget.cpp
     src/interface/widgets/cards/card_group_display_widgets/flat_card_group_display_widget.cpp
     src/interface/widgets/cards/card_group_display_widgets/overlapped_card_group_display_widget.cpp

--- a/cockatrice/src/game_graphics/player/player_graphics_item.cpp
+++ b/cockatrice/src/game_graphics/player/player_graphics_item.cpp
@@ -3,6 +3,7 @@
 #include "../../game/player/player_actions.h"
 #include "../../interface/card_picture_loader/card_picture_loader.h"
 #include "../../interface/widgets/cards/art_crop_attribution.h"
+#include "../../interface/widgets/cards/card_art_utils.h"
 #include "../../interface/widgets/playmat/playmat_utils.h"
 #include "../../interface/widgets/tabs/tab_game.h"
 #include "../board/abstract_card_item.h"
@@ -442,7 +443,7 @@ void PlayerGraphicsItem::updatePlaymat()
         hasPlaymat = true;
         emit playmatChanged(true);
     }
-    playmatPixmap = fullRes;
+    playmatPixmap = CardArtUtils::rotateSidewaysLayoutArt(fullRes, card);
     update();
 }
 

--- a/cockatrice/src/interface/widgets/cards/card_art_utils.cpp
+++ b/cockatrice/src/interface/widgets/cards/card_art_utils.cpp
@@ -1,0 +1,18 @@
+#include "card_art_utils.h"
+
+#include <QTransform>
+#include <libcockatrice/card/printing/exact_card.h>
+
+namespace CardArtUtils
+{
+QPixmap rotateSidewaysLayoutArt(const QPixmap &art, const ExactCard &card)
+{
+    if (!card.getInfo().getUiAttributes().landscapeOrientation) {
+        return art;
+    }
+
+    QTransform transform;
+    transform.rotate(90);
+    return art.transformed(transform, Qt::SmoothTransformation);
+}
+} // namespace CardArtUtils

--- a/cockatrice/src/interface/widgets/cards/card_art_utils.h
+++ b/cockatrice/src/interface/widgets/cards/card_art_utils.h
@@ -1,0 +1,25 @@
+#ifndef CARD_ART_UTILS_H
+#define CARD_ART_UTILS_H
+
+#include <QPixmap>
+
+class ExactCard;
+
+namespace CardArtUtils
+{
+/**
+ * @brief Rotates a card's art upright when its layout shows sideways.
+ *
+ * Sideways-layout cards (planes, sieges/battles, split cards) store their
+ * landscape artwork rotated 90° inside a portrait frame. Art-crop displays,
+ * playmat art, and the card-info picture must show such art upright before
+ * sampling or painting. Portrait cards are returned unchanged.
+ *
+ * @param art The card pixmap to orient.
+ * @param card The card describing the art orientation.
+ * @return @p art rotated 90° clockwise for sideways-layout cards, else @p art.
+ */
+QPixmap rotateSidewaysLayoutArt(const QPixmap &art, const ExactCard &card);
+} // namespace CardArtUtils
+
+#endif // CARD_ART_UTILS_H

--- a/cockatrice/src/interface/widgets/cards/card_info_picture_widget.cpp
+++ b/cockatrice/src/interface/widgets/cards/card_info_picture_widget.cpp
@@ -5,6 +5,7 @@
 #include "../../../interface/card_picture_loader/card_picture_loader.h"
 #include "../../../interface/widgets/tabs/tab_supervisor.h"
 #include "../../window_main.h"
+#include "card_art_utils.h"
 
 #include <QMenu>
 #include <QMouseEvent>
@@ -193,12 +194,7 @@ void CardInfoPictureWidget::paintEvent(QPaintEvent *event)
 
     QPixmap transformedPixmap = resizedPixmap; // Default pixmap
     if (SettingsCache::instance().cardsDisplay().getAutoRotateSidewaysLayoutCards()) {
-        if (exactCard.getInfo().getUiAttributes().landscapeOrientation) {
-            // Rotate pixmap 90 degrees to the left
-            QTransform transform;
-            transform.rotate(90);
-            transformedPixmap = resizedPixmap.transformed(transform, Qt::SmoothTransformation);
-        }
+        transformedPixmap = CardArtUtils::rotateSidewaysLayoutArt(resizedPixmap, exactCard);
     }
 
     // Handle DPI scaling

--- a/cockatrice/src/interface/widgets/playmat/playmat_settings_dialog.cpp
+++ b/cockatrice/src/interface/widgets/playmat/playmat_settings_dialog.cpp
@@ -2,6 +2,7 @@
 
 #include "../../card_picture_loader/card_picture_loader.h"
 #include "../cards/art_crop_attribution.h"
+#include "../cards/card_art_utils.h"
 #include "../utility/completer_utils.h"
 #include "card_database_display_model.h"
 #include "card_database_model.h"
@@ -276,7 +277,7 @@ void PlaymatSettingsDialog::reloadPreview()
         return;
     }
 
-    currentPixmap = fullRes;
+    currentPixmap = CardArtUtils::rotateSidewaysLayoutArt(fullRes, card);
     preview->setPixmap(currentPixmap);
     preview->setParams(currentParams);
     preview->setAttribution(buildArtAttribution(card));

--- a/cockatrice/src/interface/widgets/server/user/user_card_art_provider.cpp
+++ b/cockatrice/src/interface/widgets/server/user/user_card_art_provider.cpp
@@ -1,6 +1,7 @@
 #include "user_card_art_provider.h"
 
 #include "../../../card_picture_loader/card_picture_loader.h"
+#include "../../cards/card_art_utils.h"
 
 #include <QPointer>
 #include <libcockatrice/card/database/card_database_manager.h>
@@ -52,16 +53,25 @@ void UserCardArtProvider::requestCardArt(const QString &userName, const QString 
     processQueue();
 }
 
-QPixmap UserCardArtProvider::cropCardArt(const QPixmap &fullRes)
+QPixmap UserCardArtProvider::cropCardArt(const QPixmap &fullRes, const ExactCard &card)
 {
-    const QSize sz = fullRes.size();
+    QPixmap source = fullRes;
+
+    // Sideways-layout cards (plane, siege/battle, split) store their landscape
+    // artwork rotated 90° inside a portrait frame. Rotate it upright first so
+    // the crop below lands on the horizontal art, mirroring the way
+    // CardInfoPictureWidget displays these cards.
+    const bool landscape = card.getInfo().getUiAttributes().landscapeOrientation;
+    source = CardArtUtils::rotateSidewaysLayoutArt(source, card);
+
+    const QSize sz = source.size();
     const int marginX = sz.width() * 0.07;
-    const int topMargin = sz.height() * 0.11;
-    const int bottomMargin = sz.height() * 0.45;
+    const int topMargin = landscape ? sz.height() * 0.05 : sz.height() * 0.11;
+    const int bottomMargin = landscape ? sz.height() * 0.42 : sz.height() * 0.45;
 
-    const QRect foilRect(marginX, topMargin, sz.width() - 2 * marginX, sz.height() - topMargin - bottomMargin);
+    const QRect artRect(marginX, topMargin, sz.width() - 2 * marginX, sz.height() - topMargin - bottomMargin);
 
-    return fullRes.copy(foilRect.intersected(fullRes.rect()));
+    return source.copy(artRect.intersected(source.rect()));
 }
 
 void UserCardArtProvider::insertIntoCache(const QString &key, const QPixmap &pixmap)
@@ -111,7 +121,7 @@ void UserCardArtProvider::processQueue()
 
         // Synchronous hit (already loaded/on disk)
         if (!fullRes.isNull()) {
-            insertIntoCache(key, cropCardArt(fullRes));
+            insertIntoCache(key, cropCardArt(fullRes, card));
             pending.remove(key);
 
             emit cardArtUpdated(userName);
@@ -135,7 +145,7 @@ void UserCardArtProvider::processQueue()
                             CardPictureLoader::getPixmap(fullRes, card, QSize(745, 1040));
 
                             if (!fullRes.isNull()) {
-                                self->insertIntoCache(key, self->cropCardArt(fullRes));
+                                self->insertIntoCache(key, self->cropCardArt(fullRes, card));
                             }
 
                             self->pending.remove(key);

--- a/cockatrice/src/interface/widgets/server/user/user_card_art_provider.h
+++ b/cockatrice/src/interface/widgets/server/user/user_card_art_provider.h
@@ -6,6 +6,7 @@
 #include <QPixmap>
 #include <QQueue>
 #include <QSet>
+#include <libcockatrice/card/printing/exact_card.h>
 
 class UserCardArtProvider : public QObject
 {
@@ -16,7 +17,7 @@ public:
 
     void requestCardArt(const QString &userName, const QString &cardName, const QString &providerId);
     const QMap<QString, QPixmap> &cache() const;
-    static QPixmap cropCardArt(const QPixmap &fullRes);
+    static QPixmap cropCardArt(const QPixmap &fullRes, const ExactCard &card);
 
 signals:
     void cardArtUpdated(const QString &userName);

--- a/cockatrice/src/interface/widgets/server/user/user_card_settings_dialog.cpp
+++ b/cockatrice/src/interface/widgets/server/user/user_card_settings_dialog.cpp
@@ -560,7 +560,7 @@ void UserCardArtSettingsDialog::reloadPreview()
         return;
     }
 
-    currentPixmap = UserCardArtProvider::cropCardArt(fullRes);
+    currentPixmap = UserCardArtProvider::cropCardArt(fullRes, card);
     preview->setPixmap(currentPixmap);
     preview->setParams(currentParams);
 


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #7118

## Short roundup of the initial problem
Use the landscape orientation flag to rotate sideways-layout card art upright before cropping, so planes/sieges show their horizontal art as the server profile banner card instead of a rotated full card.

## What will change with this Pull Request?
- Curve cropCardArt around the card's landscapeOrientation flag with landscape-specific art margins (mirrors CardInfoPictureWidget)
- Add shared CardArtUtils::rotateSidewaysLayoutArt helper and apply it to the playmat (game render and settings preview) and card info widget, replacing three duplicate 90-degree rotation blocks
