### PR TITLE
[Servatrice] Detect MySQL strict mode on startup and exit early

### DIFF
--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -102,7 +102,7 @@ bool Servatrice_DatabaseInterface::openDatabase()
     if (isStrictModeEnabled()) {
         qCCritical(DatabaseInterfaceLog) << poolStr
                                          << "Error opening database: MySQL/MariaDB strict mode is enabled, which "
-                                            "breaks most servatrice database operations. Please disable strict mode "
+                                            "breaks most Servatrice database operations. Please disable strict mode "
                                             "by removing STRICT_TRANS_TABLES and STRICT_ALL_TABLES from sql_mode, "
                                             "for example by adding 'sql_mode=NO_ENGINE_SUBSTITUTION' under [mysqld] "
                                             "in your my.cnf (or my.ini on Windows) and restarting the database "

--- a/servatrice/src/servatrice_database_interface.cpp
+++ b/servatrice/src/servatrice_database_interface.cpp
@@ -12,6 +12,7 @@
 #include <QLoggingCategory>
 #include <QSqlError>
 #include <QSqlQuery>
+#include <QStringList>
 #include <libcockatrice/deck_list/deck_list.h>
 #include <libcockatrice/protocol/pb/game_replay.pb.h>
 #include <libcockatrice/protocol/pb/serverinfo_user.pb.h>
@@ -98,10 +99,41 @@ bool Servatrice_DatabaseInterface::openDatabase()
         return false;
     }
 
+    if (isStrictModeEnabled()) {
+        qCCritical(DatabaseInterfaceLog) << poolStr
+                                         << "Error opening database: MySQL/MariaDB strict mode is enabled, which "
+                                            "breaks most servatrice database operations. Please disable strict mode "
+                                            "by removing STRICT_TRANS_TABLES and STRICT_ALL_TABLES from sql_mode, "
+                                            "for example by adding 'sql_mode=NO_ENGINE_SUBSTITUTION' under [mysqld] "
+                                            "in your my.cnf (or my.ini on Windows) and restarting the database "
+                                            "server.";
+        return false;
+    }
+
     // reset all prepared statements
     qDeleteAll(preparedStatements);
     preparedStatements.clear();
     return true;
+}
+
+bool Servatrice_DatabaseInterface::isStrictModeEnabled() const
+{
+    if (sqlDatabase.driverName() != "QMYSQL") {
+        return false;
+    }
+
+    QSqlQuery query(sqlDatabase);
+    if (!query.exec("SELECT @@GLOBAL.sql_mode")) {
+        return false;
+    }
+
+    const QStringList modes = query.next() ? query.value(0).toString().split(',') : QStringList();
+    for (const QString &mode : modes) {
+        if (mode.trimmed() == "STRICT_TRANS_TABLES" || mode.trimmed() == "STRICT_ALL_TABLES") {
+            return true;
+        }
+    }
+    return false;
 }
 
 bool Servatrice_DatabaseInterface::checkSql()

--- a/servatrice/src/servatrice_database_interface.h
+++ b/servatrice/src/servatrice_database_interface.h
@@ -32,6 +32,7 @@ private:
     bool checkUserIsIpBanned(const QString &ipAddress, QString &banReason, int &banSecondsRemaining);
     /** Must be called after checkSql and server is known to be in auth mode. */
     bool checkUserIsNameBanned(QString const &userName, QString &banReason, int &banSecondsRemaining);
+    bool isStrictModeEnabled() const;
 
 protected:
     AuthenticationResult checkUserPassword(Server_ProtocolHandler *handler,


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #6277

## Short roundup of the initial problem
Servatrice fails on almost every database request when MySQL/MariaDB strict mode is enabled, but nothing about the errors hints that the fix is disabling strict mode.

## What will change with this Pull Request?
- Check `@@GLOBAL.sql_mode` when opening a MySQL/MariaDB connection in `Servatrice_DatabaseInterface::openDatabase()`.
- Exit early with an error message instructing how to disable strict mode when `STRICT_TRANS_TABLES` or `STRICT_ALL_TABLES` is present.