### PR TITLE
[Game] Add total toughness tally

### DIFF
--- a/cockatrice/src/game_graphics/player/menu/tally_menu.cpp
+++ b/cockatrice/src/game_graphics/player/menu/tally_menu.cpp
@@ -12,11 +12,13 @@ TallyMenu::TallyMenu()
     aTallyNone = createTallyAction(TallyType::None);
     aTallySubtypes = createTallyAction(TallyType::Subtypes);
     aTallyTotalPower = createTallyAction(TallyType::TotalPower);
+    aTallyTotalToughness = createTallyAction(TallyType::TotalToughness);
 
     addAction(aTallyNone);
     addSeparator();
     addAction(aTallySubtypes);
     addAction(aTallyTotalPower);
+    addAction(aTallyTotalToughness);
 
     retranslateUi();
 }
@@ -54,4 +56,5 @@ void TallyMenu::retranslateUi()
     aTallyNone->setText(tr("None"));
     aTallySubtypes->setText(tr("Subtypes"));
     aTallyTotalPower->setText(tr("Total Power"));
+    aTallyTotalToughness->setText(tr("Total Toughness"));
 }

--- a/cockatrice/src/game_graphics/player/menu/tally_menu.h
+++ b/cockatrice/src/game_graphics/player/menu/tally_menu.h
@@ -24,6 +24,7 @@ private:
     QAction *aTallyNone = nullptr;
     QAction *aTallySubtypes = nullptr;
     QAction *aTallyTotalPower = nullptr;
+    QAction *aTallyTotalToughness = nullptr;
 
     QAction *createTallyAction(TallyType tallyType);
 };

--- a/cockatrice/src/game_graphics/tally/stats_tally.cpp
+++ b/cockatrice/src/game_graphics/tally/stats_tally.cpp
@@ -34,3 +34,31 @@ QList<TallyRow> StatsTally::computeTotalPower(const QList<CardItem *> &cards)
     QString name = QCoreApplication::translate("StatsTally", "Total Power");
     return {TallyRow{name, QString::number(total)}};
 }
+
+static int sumToughness(const QList<CardItem *> &cards)
+{
+    int total = 0;
+    for (auto card : cards) {
+        QVariantList parsed = CardItem::parsePT(card->getPT());
+        if (parsed.size() == 2) {
+            int toughness = parsed.at(1).toInt(); // toInt will default to 0 if it's not an int
+            total += qMax(toughness, 0);
+        }
+    }
+    return total;
+}
+
+QList<TallyRow> StatsTally::computeTotalToughness(const QList<CardItem *> &cards)
+{
+    // don't bother if none of the cards have pt
+    bool hasPT =
+        std::any_of(cards.cbegin(), cards.cend(), [](const CardItem *card) { return !card->getPT().isEmpty(); });
+    if (!hasPT) {
+        return {};
+    }
+
+    int total = sumToughness(cards);
+
+    QString name = QCoreApplication::translate("StatsTally", "Total Toughness");
+    return {TallyRow{name, QString::number(total)}};
+}

--- a/cockatrice/src/game_graphics/tally/stats_tally.h
+++ b/cockatrice/src/game_graphics/tally/stats_tally.h
@@ -16,6 +16,14 @@ namespace StatsTally
  */
 QList<TallyRow> computeTotalPower(const QList<CardItem *> &cards);
 
+/**
+ * @brief Sums the toughness of all selected cards
+ *
+ * @param cards The list of selected card items to analyze.
+ * @return A single row containing the total, or an empty list if none of the cards have pt
+ */
+QList<TallyRow> computeTotalToughness(const QList<CardItem *> &cards);
+
 } // namespace StatsTally
 
 #endif // COCKATRICE_STATS_TALLY_H

--- a/cockatrice/src/game_graphics/tally/tally.cpp
+++ b/cockatrice/src/game_graphics/tally/tally.cpp
@@ -21,6 +21,8 @@ QList<TallyRow> Tally::compute(const QList<CardItem *> &cards, const TallyType t
             return SubtypeTally::countSubtypes(cards);
         case TallyType::TotalPower:
             return StatsTally::computeTotalPower(cards);
+        case TallyType::TotalToughness:
+            return StatsTally::computeTotalToughness(cards);
     }
     return {};
 }

--- a/cockatrice/src/game_graphics/tally/tally.h
+++ b/cockatrice/src/game_graphics/tally/tally.h
@@ -21,7 +21,8 @@ enum class TallyType
     None,
     Subtypes,
     TotalPower,
-    MaxValue = TotalPower // sentinel value
+    TotalToughness,
+    MaxValue = TotalToughness // sentinel value
 };
 
 namespace Tally


### PR DESCRIPTION
## Related Ticket(s)
- Follow-up to #7057

## Short roundup of the initial problem

I want to know if my big tramply guy can attack for lethal into my opponent's board.

## What will change with this Pull Request?

https://github.com/user-attachments/assets/3cd61cad-dea8-49e2-b61a-016e16f7b4b4

- Add `Total Toughness` tally type and updated tally menu with it
  - Has same logic as power tally in that it won't show anything unless at least one selected card has a nonempty p/t 
  - Uses `CardItem::parsePT` to get p/t, and treats any card that doesn't have a toughness as 0