### PR TITLE
[Oracle] Have space between size value and unit

### DIFF
--- a/oracle/src/pages.cpp
+++ b/oracle/src/pages.cpp
@@ -577,7 +577,7 @@ void SaveSetsPage::retranslateUi()
 {
     setTitle(tr("Sets imported"));
     if (wizard()->downloadedPlainXml) {
-        setSubTitle(tr("A Cockatrice card database file of %1 MB has been downloaded.")
+        setSubTitle(tr("A cockatrice database file of %1 MB has been downloaded.")
                         .arg(qRound(wizard()->xmlData.size() / 1000000.0)));
     } else {
         setSubTitle(tr("The following sets have been found:"));

--- a/oracle/src/pages.cpp
+++ b/oracle/src/pages.cpp
@@ -260,7 +260,7 @@ bool LoadSetsPage::validatePage()
             return false;
         }
 
-        progressLabel->setText(tr("Downloading (0MB)"));
+        progressLabel->setText(tr("Downloading (0 MB)"));
         // show an infinite progressbar
         progressBar->setMaximum(0);
         progressBar->setMinimum(0);
@@ -343,7 +343,7 @@ void LoadSetsPage::actDownloadProgressSetsFile(qint64 received, qint64 total)
         progressBar->setMaximum(static_cast<int>(total));
         progressBar->setValue(static_cast<int>(received));
     }
-    progressLabel->setText(tr("Downloading (%1MB)").arg((int)received / (1024 * 1024)));
+    progressLabel->setText(tr("Downloading (%1 MB)").arg((int)received / (1024 * 1024)));
 }
 
 void LoadSetsPage::actDownloadFinishedSetsFile()
@@ -577,7 +577,7 @@ void SaveSetsPage::retranslateUi()
 {
     setTitle(tr("Sets imported"));
     if (wizard()->downloadedPlainXml) {
-        setSubTitle(tr("A cockatrice database file of %1 MB has been downloaded.")
+        setSubTitle(tr("A Cockatrice card database file of %1 MB has been downloaded.")
                         .arg(qRound(wizard()->xmlData.size() / 1000000.0)));
     } else {
         setSubTitle(tr("The following sets have been found:"));


### PR DESCRIPTION
## Short roundup of the initial problem
UI values feel a bit cramped.
For "%" it's more natural to have no space, see https://github.com/Cockatrice/Cockatrice/pull/7253#pullrequestreview-5124995384

## What will change with this Pull Request?
- Introduce space between quantity value and unit of measure ("MB").

## Screenshots
<img width="635" height="496" alt="image" src="https://github.com/user-attachments/assets/236fb6a7-f04c-42e4-a64b-58e4d0bba467" />
