### PR TITLE
[Client] Add setting to ignore all private messages

### DIFF
--- a/cockatrice/src/interface/widgets/settings_page/messages_settings_page.cpp
+++ b/cockatrice/src/interface/widgets/settings_page/messages_settings_page.cpp
@@ -59,6 +59,10 @@ MessagesSettingsPage::MessagesSettingsPage()
     connect(&roomHistory, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance().chat(),
             &ChatSettings::setRoomHistory);
 
+    ignoreAllPrivateMessagesCheckBox.setChecked(SettingsCache::instance().chat().getIgnoreAllPrivateMessages());
+    connect(&ignoreAllPrivateMessagesCheckBox, &QCheckBox::QT_STATE_CHANGED, &SettingsCache::instance().chat(),
+            &ChatSettings::setIgnoreAllPrivateMessages);
+
     customAlertString = new QLineEdit();
     customAlertString->setText(SettingsCache::instance().chat().getHighlightWords());
     connect(customAlertString, &QLineEdit::textChanged, &SettingsCache::instance().chat(),
@@ -76,6 +80,7 @@ MessagesSettingsPage::MessagesSettingsPage()
     chatGrid->addWidget(&messagePopups, 5, 0);
     chatGrid->addWidget(&mentionPopups, 6, 0);
     chatGrid->addWidget(&roomHistory, 7, 0);
+    chatGrid->addWidget(&ignoreAllPrivateMessagesCheckBox, 8, 0);
     chatGroupBox = new QGroupBox;
     chatGroupBox->setLayout(chatGrid);
 
@@ -256,6 +261,7 @@ void MessagesSettingsPage::retranslateUi()
     messagePopups.setText(tr("Enable desktop notifications for private messages"));
     mentionPopups.setText(tr("Enable desktop notification for mentions"));
     roomHistory.setText(tr("Enable room message history on join"));
+    ignoreAllPrivateMessagesCheckBox.setText(tr("Ignore all private messages"));
     hexLabel.setText(tr("(Color is hexadecimal)"));
     hexHighlightLabel.setText(tr("(Color is hexadecimal)"));
     customAlertStringLabel.setText(tr("Separate words with a space, alphanumeric characters only"));

--- a/cockatrice/src/interface/widgets/settings_page/messages_settings_page.h
+++ b/cockatrice/src/interface/widgets/settings_page/messages_settings_page.h
@@ -40,6 +40,7 @@ private:
     QCheckBox messagePopups;
     QCheckBox mentionPopups;
     QCheckBox roomHistory;
+    QCheckBox ignoreAllPrivateMessagesCheckBox;
     QGroupBox *chatGroupBox;
     QGroupBox *highlightGroupBox;
     QGroupBox *messageGroupBox;

--- a/cockatrice/src/interface/widgets/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_supervisor.cpp
@@ -1277,7 +1277,22 @@ void TabSupervisor::processGameEventContainer(const GameEventContainer &cont)
 
 void TabSupervisor::processUserMessageEvent(const Event_UserMessage &event)
 {
+    // "Ignore all private messages" silences every PM, including messages to
+    // already-open tabs — unlike the unregistered/non-buddy filters below,
+    // which only apply when creating a new tab. Messages from moderators/admins
+    // are exempt to ensure warnings still reach users.
     QString senderName = QString::fromStdString(event.sender_name());
+    if (SettingsCache::instance().chat().getIgnoreAllPrivateMessages()) {
+        const ServerInfo_User *onlineUserInfo = userListManager->getOnlineUser(senderName);
+        if (onlineUserInfo) {
+            const UserLevelFlags userLevel(onlineUserInfo->user_level());
+            if (!userLevel.testFlag(ServerInfo_User::IsModerator) && !userLevel.testFlag(ServerInfo_User::IsAdmin)) {
+                return;
+            }
+        } else {
+            return;
+        }
+    }
     TabMessage *tab = messageTabs.value(senderName);
     if (!tab) {
         tab = messageTabs.value(QString::fromStdString(event.receiver_name()));

--- a/cockatrice/src/interface/widgets/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_supervisor.cpp
@@ -1284,12 +1284,11 @@ void TabSupervisor::processUserMessageEvent(const Event_UserMessage &event)
     QString senderName = QString::fromStdString(event.sender_name());
     if (SettingsCache::instance().chat().getIgnoreAllPrivateMessages()) {
         const ServerInfo_User *onlineUserInfo = userListManager->getOnlineUser(senderName);
-        if (onlineUserInfo) {
-            const UserLevelFlags userLevel(onlineUserInfo->user_level());
-            if (!userLevel.testFlag(ServerInfo_User::IsModerator) && !userLevel.testFlag(ServerInfo_User::IsAdmin)) {
-                return;
-            }
-        } else {
+        if (!onlineUserInfo) {
+            return;
+        }
+        const UserLevelFlags userLevel(onlineUserInfo->user_level());
+        if (!userLevel.testFlag(ServerInfo_User::IsModerator) && !userLevel.testFlag(ServerInfo_User::IsAdmin)) {
             return;
         }
     }

--- a/libcockatrice_interfaces/libcockatrice/interfaces/interface_chat_settings_provider.h
+++ b/libcockatrice_interfaces/libcockatrice/interfaces/interface_chat_settings_provider.h
@@ -20,6 +20,7 @@ public:
     [[nodiscard]] virtual bool getShowMessagePopup() const = 0;
     [[nodiscard]] virtual bool getShowMentionPopup() const = 0;
     [[nodiscard]] virtual bool getRoomHistory() const = 0;
+    [[nodiscard]] virtual bool getIgnoreAllPrivateMessages() const = 0;
     [[nodiscard]] virtual QString getHighlightWords() const = 0;
 };
 

--- a/libcockatrice_settings/libcockatrice/settings/chat_settings.cpp
+++ b/libcockatrice_settings/libcockatrice/settings/chat_settings.cpp
@@ -65,6 +65,11 @@ bool ChatSettings::getRoomHistory() const
     return getValue("roomHistory", QString(), QString(), true).toBool();
 }
 
+bool ChatSettings::getIgnoreAllPrivateMessages() const
+{
+    return getValue("ignoreAllPrivateMessages", QString(), QString(), false).toBool();
+}
+
 QString ChatSettings::getHighlightWords() const
 {
     return getValue("highlightWords").toString();
@@ -129,6 +134,11 @@ void ChatSettings::setShowMentionPopups(bool _showMentionPopups)
 void ChatSettings::setRoomHistory(bool _roomHistory)
 {
     setValue(_roomHistory, "roomHistory");
+}
+
+void ChatSettings::setIgnoreAllPrivateMessages(bool _ignoreAllPrivateMessages)
+{
+    setValue(_ignoreAllPrivateMessages, "ignoreAllPrivateMessages");
 }
 
 void ChatSettings::setHighlightWords(const QString &_highlightWords)

--- a/libcockatrice_settings/libcockatrice/settings/chat_settings.h
+++ b/libcockatrice_settings/libcockatrice/settings/chat_settings.h
@@ -23,6 +23,7 @@ public:
     [[nodiscard]] bool getShowMessagePopup() const override;
     [[nodiscard]] bool getShowMentionPopup() const override;
     [[nodiscard]] bool getRoomHistory() const override;
+    [[nodiscard]] bool getIgnoreAllPrivateMessages() const override;
     [[nodiscard]] QString getHighlightWords() const override;
 
     void setChatMention(bool _chatMention);
@@ -37,6 +38,7 @@ public:
     void setShowMessagePopups(bool _showMessagePopups);
     void setShowMentionPopups(bool _showMentionPopups);
     void setRoomHistory(bool _roomHistory);
+    void setIgnoreAllPrivateMessages(bool _ignoreAllPrivateMessages);
     void setHighlightWords(const QString &_highlightWords);
 
 signals:

--- a/tests/settings/settings_defaults_test.cpp
+++ b/tests/settings/settings_defaults_test.cpp
@@ -300,6 +300,12 @@ TEST_F(SettingsDefaultsTest, Chat_RoomHistory_Default)
     ASSERT_EQ(s.getRoomHistory(), true);
 }
 
+TEST_F(SettingsDefaultsTest, Chat_IgnoreAllPrivateMessages_Default)
+{
+    ChatSettings s(settingsPath, nullptr);
+    ASSERT_EQ(s.getIgnoreAllPrivateMessages(), false);
+}
+
 // --- PersonalSettings ---
 
 TEST_F(SettingsDefaultsTest, Personal_Lang_Default)


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #1250

## Short roundup of the initial problem
Users don't want to receive any direct messages at all.

## What will change with this Pull Request?
- Add a new option allowing just that
- Exempt Moderators and Admins from this check
