### PR TITLE
[Client] Show confirmation when adding a user to the ignore list

### DIFF
--- a/cockatrice/src/interface/widgets/server/user/user_context_menu.cpp
+++ b/cockatrice/src/interface/widgets/server/user/user_context_menu.cpp
@@ -606,7 +606,15 @@ void UserContextMenu::execAddToIgnore(const QString &userName)
     Command_AddToList cmd;
     cmd.set_list("ignore");
     cmd.set_user_name(userName.toStdString());
-    client->sendCommand(client->prepareSessionCommand(cmd));
+    PendingCommand *pend = client->prepareSessionCommand(cmd);
+    connect(pend, &PendingCommand::finished, this,
+            [this, userName](const Response &response, const CommandContainer &, const QVariant &) {
+                if (response.response_code() == Response::RespOk) {
+                    QMessageBox::information(static_cast<QWidget *>(parent()), tr("Ignore list"),
+                                             tr("%1 has been added to your ignore list.").arg(userName));
+                }
+            });
+    client->sendCommand(pend);
 }
 
 void UserContextMenu::execRemoveFromIgnore(const QString &userName)


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #1875

## Short roundup of the initial problem
Nothing in the UI confirmed that a user had been added to the ignore list, so the action felt ambiguous and could be repeated by accident.

## What will change with this Pull Request?
- Show an information dialog when the server acknowledges the add-to-ignore command.
