### PR TITLE
[Client] Prevent contacting users on the ignore list

### DIFF
--- a/cockatrice/src/interface/widgets/server/user/user_context_menu.cpp
+++ b/cockatrice/src/interface/widgets/server/user/user_context_menu.cpp
@@ -439,7 +439,7 @@ void UserContextMenu::showContextMenu(const QPoint &pos,
         }
     }
     aDetails->setEnabled(true);
-    aChat->setEnabled(anotherUser && online);
+    aChat->setEnabled(anotherUser && online && !userListProxy->isUserIgnored(userName));
     aShowGames->setEnabled(online);
     aReport->setEnabled(anotherUser);
     aAddToBuddyList->setEnabled(anotherUser);

--- a/cockatrice/src/interface/widgets/tabs/tab_message.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_message.cpp
@@ -99,7 +99,7 @@ void TabMessage::closeEvent(QCloseEvent *event)
 void TabMessage::sendPrivateMessage(const QString &text)
 {
     if (tabSupervisor->getUserListManager()->isUserIgnored(getUserName())) {
-        chatView->appendMessage(tr("You have ignored %1, your messages are not delivered.")
+        chatView->appendMessage(tr("You have ignored %1; your messages are not delivered.")
                                     .arg(QString::fromStdString(otherUserInfo->name())));
         return;
     }

--- a/cockatrice/src/interface/widgets/tabs/tab_message.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_message.cpp
@@ -98,6 +98,12 @@ void TabMessage::closeEvent(QCloseEvent *event)
 
 void TabMessage::sendPrivateMessage(const QString &text)
 {
+    if (tabSupervisor->getUserListManager()->isUserIgnored(getUserName())) {
+        chatView->appendMessage(tr("You have ignored %1, your messages are not delivered.")
+                                    .arg(QString::fromStdString(otherUserInfo->name())));
+        return;
+    }
+
     Command_Message cmd;
     cmd.set_user_name(otherUserInfo->name());
     cmd.set_message(text.toStdString());

--- a/cockatrice/src/interface/widgets/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_supervisor.cpp
@@ -1063,6 +1063,13 @@ TabMessage *TabSupervisor::addMessageTab(const QString &receiverName, bool focus
         return tab;
     }
 
+    if (focus && userListManager->isUserIgnored(receiverName)) {
+        QMessageBox::information(
+            this, tr("Ignored user"),
+            tr("You have ignored %1. Remove them from your ignore list to open a private chat.").arg(receiverName));
+        return nullptr;
+    }
+
     tab = new TabMessage(this, client, *userInfo, otherUser, userOnline);
     connect(tab, &TabMessage::talkClosing, this, &TabSupervisor::talkLeft);
     connect(tab, &TabMessage::maximizeClient, this, &TabSupervisor::maximizeMainWindow);


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #1249

## Short roundup of the initial problem
The ignore list silences incoming messages, but a user on it was still reachable: the context menu's chat item stayed enabled, private messages could be sent, and a chat tab could be opened for an ignored user.

## What will change with this Pull Request?
- Make ignored users uncontactable: disable the chat item for them, refuse to deliver messages typed in an open PM tab with one, and refuse to open a new private chat tab with an ignored user (with a hint on how to undo the ignore).
