### PR TITLE
[Game] Don't alert game tab for spectator activity

### DIFF
--- a/cockatrice/src/game/game_event_handler.cpp
+++ b/cockatrice/src/game/game_event_handler.cpp
@@ -255,8 +255,6 @@ void GameEventHandler::eventSpectatorLeave(const Event_Leave &event,
     emit spectatorLeft(eventPlayerId);
 
     game->getPlayerManager()->removeSpectator(eventPlayerId);
-
-    emitUserEvent();
 }
 
 void GameEventHandler::eventGameStateChanged(const Event_GameStateChanged &event,
@@ -442,9 +440,9 @@ void GameEventHandler::eventJoin(const Event_Join &event, int /*eventPlayerId*/,
         PlayerLogic *newPlayer = game->getPlayerManager()->addPlayer(playerId, playerInfo.user_info());
         emit logJoinPlayer(newPlayer);
         emit playerJoined(playerInfo);
-    }
 
-    emitUserEvent();
+        emitUserEvent();
+    }
 }
 
 QString GameEventHandler::getLeaveReason(Event_Leave::LeaveReason reason)


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #1848

## Short roundup of the initial problem
Spectator join/leave events were triggering the game tab's attention indicator (exclamation mark and taskbar alert) for players who often leave the tab open while waiting for an opponent. This made spectator activity a false alarm.

## What will change with this Pull Request?
- Only emit the user event when an actual player joins or leaves, keeping spectator joins/leaves quiet.
