### PR TITLE
[Settings] Make chat settings page scrollable

### DIFF
--- a/cockatrice/src/interface/widgets/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_settings.cpp
@@ -132,7 +132,7 @@ void DlgSettings::setupUi()
     pagesWidget->addWidget(makeScrollable(userInterfacePage));
     pagesWidget->addWidget(makeScrollable(deckEditorPage));
     pagesWidget->addWidget(makeScrollable(storagePage));
-    pagesWidget->addWidget(messagesPage);
+    pagesWidget->addWidget(makeScrollable(messagesPage));
     pagesWidget->addWidget(soundPage);
     pagesWidget->addWidget(shortcutsPage);
 


### PR DESCRIPTION
### Related Ticket(s)
- Follow-up to #7260

## Short roundup of the initial problem

Chat settings page is starting to become really cramped after adding more settings recently.

<img width="753" height="775" alt="Screenshot 2026-09-06 at 11 53 21 PM" src="https://github.com/user-attachments/assets/d89351ac-b44e-4db2-8882-1978127c1c62" />

## What will change with this Pull Request?

Make the chat settings page scrollable

https://github.com/user-attachments/assets/88bad490-f513-4fe9-8594-30b1957034fa