### PR TITLE
[Oracle] Prefer higher-priority maintype when merging split cards

### DIFF
--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -460,8 +460,17 @@ int OracleImporter::importCardsFromSet(const CardSetPtr &currentSet, const QJson
                             properties.insert(prop, thisCardPropertyValue);
                         } else if (prop == "colors" || prop == "coloridentity") { // the card is both colors
                             properties.insert(prop, originalPropertyValue + thisCardPropertyValue);
-                        } else if (prop == "maintype") { // don't create maintypes with //es in them
-                            continue;
+                        } else if (prop == "maintype") {
+                            // Use the same priority as getMainCardType() to pick the
+                            // "best" type across faces — e.g. Creature over Instant
+                            // for adventure cards.
+                            static const QStringList typePriority = {
+                                "Planeswalker", "Creature", "Land", "Sorcery", "Instant", "Artifact", "Enchantment"};
+                            int currentPriority = typePriority.indexOf(originalPropertyValue);
+                            int newPriority = typePriority.indexOf(thisCardPropertyValue);
+                            if (newPriority >= 0 && (currentPriority < 0 || newPriority < currentPriority)) {
+                                properties.insert(prop, thisCardPropertyValue);
+                            }
                         } else {
                             properties.insert(prop,
                                               originalPropertyValue + splitCardPropSeparator + thisCardPropertyValue);

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -101,12 +101,8 @@ bool OracleImporter::readSetsFromByteArray(QByteArray data)
  * types (e.g. "Artifact Creature") or multiple faces (e.g. split/adventure cards).
  * A lower index means a higher priority.
  */
-static const QStringList &mainCardTypePriority()
-{
-    static const QStringList priority = {"Planeswalker", "Creature", "Land",       "Sorcery",
-                                         "Instant",      "Artifact", "Enchantment"};
-    return priority;
-}
+static const QStringList MAIN_CARD_TYPE_PRIORITY = {"Planeswalker", "Creature", "Land",       "Sorcery",
+                                                     "Instant",      "Artifact", "Enchantment"};
 
 /**
  * Returns the priority (index) of the given main card type. Known types map to their
@@ -114,7 +110,7 @@ static const QStringList &mainCardTypePriority()
  */
 static int mainCardTypePriority(const QString &mainCardType)
 {
-    return mainCardTypePriority().indexOf(mainCardType);
+    return MAIN_CARD_TYPE_PRIORITY.indexOf(mainCardType);
 }
 
 static QString getMainCardType(const QStringList &typeList)
@@ -123,7 +119,7 @@ static QString getMainCardType(const QStringList &typeList)
         return {};
     }
 
-    for (const auto &type : mainCardTypePriority()) {
+    for (const auto &type : MAIN_CARD_TYPE_PRIORITY) {
         if (typeList.contains(type)) {
             return type;
         }

--- a/oracle/src/oracleimporter.cpp
+++ b/oracle/src/oracleimporter.cpp
@@ -96,16 +96,34 @@ bool OracleImporter::readSetsFromByteArray(QByteArray data)
     return true;
 }
 
+/**
+ * The priority order used to pick a card's main type when a card has multiple
+ * types (e.g. "Artifact Creature") or multiple faces (e.g. split/adventure cards).
+ * A lower index means a higher priority.
+ */
+static const QStringList &mainCardTypePriority()
+{
+    static const QStringList priority = {"Planeswalker", "Creature", "Land",       "Sorcery",
+                                         "Instant",      "Artifact", "Enchantment"};
+    return priority;
+}
+
+/**
+ * Returns the priority (index) of the given main card type. Known types map to their
+ * position in {@link mainCardTypePriority()}, unknown types map to -1 (lowest priority).
+ */
+static int mainCardTypePriority(const QString &mainCardType)
+{
+    return mainCardTypePriority().indexOf(mainCardType);
+}
+
 static QString getMainCardType(const QStringList &typeList)
 {
     if (typeList.isEmpty()) {
         return {};
     }
 
-    static const QStringList typePriority = {"Planeswalker", "Creature", "Land",       "Sorcery",
-                                             "Instant",      "Artifact", "Enchantment"};
-
-    for (const auto &type : typePriority) {
+    for (const auto &type : mainCardTypePriority()) {
         if (typeList.contains(type)) {
             return type;
         }
@@ -463,11 +481,9 @@ int OracleImporter::importCardsFromSet(const CardSetPtr &currentSet, const QJson
                         } else if (prop == "maintype") {
                             // Use the same priority as getMainCardType() to pick the
                             // "best" type across faces — e.g. Creature over Instant
-                            // for adventure cards.
-                            static const QStringList typePriority = {
-                                "Planeswalker", "Creature", "Land", "Sorcery", "Instant", "Artifact", "Enchantment"};
-                            int currentPriority = typePriority.indexOf(originalPropertyValue);
-                            int newPriority = typePriority.indexOf(thisCardPropertyValue);
+                            // for adventure cards like Bonecrusher Giant.
+                            int currentPriority = mainCardTypePriority(originalPropertyValue);
+                            int newPriority = mainCardTypePriority(thisCardPropertyValue);
                             if (newPriority >= 0 && (currentPriority < 0 || newPriority < currentPriority)) {
                                 properties.insert(prop, thisCardPropertyValue);
                             }


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #4394

## Short roundup of the initial problem
Adventure cards (e.g. Bonecrusher Giant, Virtue of Knowledge) are stored as split cards in MTGJSON, with a Creature/permanent face and an Instant/Sorcery adventure face. When the two faces are merged into a single card, the code previously discarded the second face's maintype entirely, keeping whichever face was processed first.

If the Instant/Sorcery adventure face appeared first, the merged card got maintype 'Instant' with tableRow 3. At runtime this made double-clicking the card on the stack send it to the graveyard instead of the table (PlayerActions::playCard).

## What will change with this Pull Request?
Fix the merge to follow the same priority order used by getMainCardType() (Planeswalker > Creature > Land > Sorcery > Instant > Artifact > Enchantment), so the permanent Creature type wins for adventure cards regardless of face order, matching the physical card and the reported expectations.
