### PR TITLE
[Game] Stop duplicate attach log entries

### DIFF
--- a/cockatrice/src/game_graphics/board/card_item.cpp
+++ b/cockatrice/src/game_graphics/board/card_item.cpp
@@ -316,7 +316,7 @@ void CardItem::drawAttachArrow()
 
     for (const auto &item : scene()->selectedItems()) {
         CardItem *card = qgraphicsitem_cast<CardItem *>(item);
-        if (card == nullptr) {
+        if (card == nullptr || card == this) {
             continue;
         }
         if (card->getZone() != state->getZone()) {


### PR DESCRIPTION
## Short roundup of the initial problem
Fix duplicate attach messages in the game log caused by a redundant child arrow in CardItem::drawAttachArrow.

Unlike the sibling drawArrow, drawAttachArrow omitted the ``card == this`` guard when iterating selectedItems(). Because right-clicking a card to open the attach menu selects that card, it was always present in selectedItems(), producing a second arrow for the same source card.

On release both arrows sent an identical Command_AttachCard, so the server broadcast two Event_AttachCard messages and the log rendered "attaches to" twice.

## What will change with this Pull Request?
- Mirror the drawArrow skip condition so the active card is excluded and only one attach command is sent.
