### PR TITLE
[PictureLoader] Leave failed pixmap null so solid color is shown instead

### DIFF
--- a/cockatrice/src/interface/card_picture_loader/card_picture_loader.cpp
+++ b/cockatrice/src/interface/card_picture_loader/card_picture_loader.cpp
@@ -138,7 +138,8 @@ void CardPictureLoader::getPixmap(QPixmap &pixmap, const ExactCard &card, QSize 
     QPixmap bigPixmap;
     if (QPixmapCache::find(key, &bigPixmap)) {
         if (bigPixmap.isNull()) {
-            getCardBackLoadingFailedPixmap(pixmap, size);
+            // Leave the pixmap null so callers fall back to a solid color
+            // instead of showing the card back.
             QDateTime failedAtTime = getInstance().failedAt.value(key);
             if (!failedAtTime.isValid() ||
                 failedAtTime.addSecs(RETRY_FAILED_CARDS_SECS) < QDateTime::currentDateTime()) {


### PR DESCRIPTION
## Related Ticket(s)
- Fixes #7147

## Short roundup of the initial problem


## What will change with this Pull Request?
- this
- and this
