### PR TITLE
[Theme] Migrate theme asset loads to scheme-variant resolution

### DIFF
--- a/cockatrice/src/client/network/connection_controller/remote_connection_controller.cpp
+++ b/cockatrice/src/client/network/connection_controller/remote_connection_controller.cpp
@@ -1,5 +1,6 @@
 #include "remote_connection_controller.h"
 
+#include "../../../interface/pixel_map_generator.h"
 #include "../../settings/cache_settings.h"
 #include "../interface/widgets/dialogs/dlg_connect.h"
 #include "../interface/widgets/dialogs/dlg_forgot_password_challenge.h"
@@ -180,7 +181,7 @@ void ConnectionController::onServerShutdownEvent(const Event_ServerShutdown &eve
                                                    "games will be lost.\nReason for shutdown: %1",
                                                    "", event.minutes())
                                                     .arg(QString::fromStdString(event.reason())));
-    serverShutdownMessageBox.setIconPixmap(QPixmap("theme:cockatrice").scaled(64, 64));
+    serverShutdownMessageBox.setIconPixmap(themePixmap(QStringLiteral("cockatrice")).scaled(64, 64));
     serverShutdownMessageBox.setText(tr("Scheduled server shutdown"));
     serverShutdownMessageBox.setWindowModality(Qt::ApplicationModal);
     serverShutdownMessageBox.setVisible(true);

--- a/cockatrice/src/filters/filter_builder.cpp
+++ b/cockatrice/src/filters/filter_builder.cpp
@@ -1,5 +1,6 @@
 #include "filter_builder.h"
 
+#include "../interface/pixel_map_generator.h"
 #include "../interface/widgets/utility/custom_line_edit.h"
 
 #include <QComboBox>
@@ -21,7 +22,7 @@ FilterBuilder::FilterBuilder(QWidget *parent) : QWidget(parent)
         typeCombo->addItem(CardFilter::typeName(static_cast<CardFilter::Type>(i)), QVariant(i));
     }
 
-    QPushButton *ok = new QPushButton(QPixmap("theme:icons/increment"), QString());
+    QPushButton *ok = new QPushButton(themePixmap(QStringLiteral("icons/increment")), QString());
     ok->setObjectName("ok");
     ok->setMaximumSize(20, 20);
 

--- a/cockatrice/src/game_graphics/hand_counter.cpp
+++ b/cockatrice/src/game_graphics/hand_counter.cpp
@@ -1,5 +1,6 @@
 #include "hand_counter.h"
 
+#include "../interface/pixel_map_generator.h"
 #include "zones/card_zone.h"
 
 #include <QGraphicsSceneMouseEvent>
@@ -32,7 +33,8 @@ void HandCounter::paint(QPainter *painter, const QStyleOptionGraphicsItem * /*op
     QSize translatedSize = painter->combinedTransform().mapRect(boundingRect()).size().toSize();
     QPixmap cachedPixmap;
     if (!QPixmapCache::find("handCounter" + QString::number(translatedSize.width()), &cachedPixmap)) {
-        cachedPixmap = QPixmap("theme:hand").scaled(translatedSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+        cachedPixmap =
+            themePixmap(QStringLiteral("hand")).scaled(translatedSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
         QPixmapCache::insert("handCounter" + QString::number(translatedSize.width()), cachedPixmap);
     }
     resetPainterTransform(painter);

--- a/cockatrice/src/game_graphics/player/player_list_widget.cpp
+++ b/cockatrice/src/game_graphics/player/player_list_widget.cpp
@@ -53,13 +53,13 @@ PlayerListWidget::PlayerListWidget(TabSupervisor *_tabSupervisor,
                                    QWidget *parent)
     : QTreeWidget(parent), tabSupervisor(_tabSupervisor), client(_client), game(_game), gameStarted(false)
 {
-    readyIcon = QPixmap("theme:icons/ready_start");
-    notReadyIcon = QPixmap("theme:icons/not_ready_start");
-    concededIcon = QPixmap("theme:icons/conceded");
+    readyIcon = themePixmap(QStringLiteral("icons/ready_start"));
+    notReadyIcon = themePixmap(QStringLiteral("icons/not_ready_start"));
+    concededIcon = themePixmap(QStringLiteral("icons/conceded"));
     playerIcon = loadColorAdjustedPixmap("theme:icons/player");
     judgeIcon = loadColorAdjustedPixmap("theme:icons/scales");
     spectatorIcon = loadColorAdjustedPixmap("theme:icons/spectator");
-    lockIcon = QPixmap("theme:icons/lock");
+    lockIcon = themePixmap(QStringLiteral("icons/lock"));
 
     if (tabSupervisor) {
         itemDelegate = new PlayerListItemDelegate(this);

--- a/cockatrice/src/game_graphics/zones/view_zone_widget.cpp
+++ b/cockatrice/src/game_graphics/zones/view_zone_widget.cpp
@@ -62,7 +62,7 @@ ZoneViewWidget::ZoneViewWidget(PlayerLogic *_player,
         searchEdit.setPlaceholderText(tr("Search by card name (or search expressions)"));
         searchEdit.setClearButtonEnabled(true);
         searchEdit.addAction(loadColorAdjustedPixmap("theme:icons/search"), QLineEdit::LeadingPosition);
-        auto help = searchEdit.addAction(QPixmap("theme:icons/info"), QLineEdit::TrailingPosition);
+        auto help = searchEdit.addAction(themePixmap(QStringLiteral("icons/info")), QLineEdit::TrailingPosition);
 
         connect(help, &QAction::triggered, this, [this] { createSearchSyntaxHelpWindow(&searchEdit); });
 
@@ -549,7 +549,7 @@ void ZoneViewWidget::initStyleOption(QStyleOption *option) const
 {
     QStyleOptionTitleBar *titleBar = qstyleoption_cast<QStyleOptionTitleBar *>(option);
     if (titleBar) {
-        titleBar->icon = QPixmap("theme:cockatrice");
+        titleBar->icon = themePixmap(QStringLiteral("cockatrice"));
     }
 }
 

--- a/cockatrice/src/interface/card_picture_loader/card_picture_loader.cpp
+++ b/cockatrice/src/interface/card_picture_loader/card_picture_loader.cpp
@@ -1,6 +1,7 @@
 #include "card_picture_loader.h"
 
 #include "../../client/settings/cache_settings.h"
+#include "../pixel_map_generator.h"
 #include "card_picture_loader_cache_method.h"
 #include "card_picture_loader_local_schemes.h"
 
@@ -62,7 +63,7 @@ void CardPictureLoader::getCardBackPixmap(QPixmap &pixmap, QSize size)
     QString backCacheKey = "_trice_card_back_" + QString::number(size.width()) + "x" + QString::number(size.height());
     if (!QPixmapCache::find(backCacheKey, &pixmap)) {
         qCDebug(CardPictureLoaderLog) << "PictureLoader: cache miss for" << backCacheKey;
-        QPixmap tmpPixmap("theme:cardback");
+        QPixmap tmpPixmap = themePixmap(QStringLiteral("cardback"));
 
         if (tmpPixmap.isNull()) {
             qCWarning(CardPictureLoaderLog) << "Failed to load 'theme:cardback'! Using fallback pixmap.";
@@ -83,7 +84,7 @@ void CardPictureLoader::getCardBackLoadingInProgressPixmap(QPixmap &pixmap, QSiz
         "_trice_card_back_inprogress_" + QString::number(size.width()) + "x" + QString::number(size.height());
     if (!QPixmapCache::find(backCacheKey, &pixmap)) {
         qCDebug(CardPictureLoaderCardBackCacheFailLog) << "PictureLoader: cache miss for" << backCacheKey;
-        QPixmap tmpPixmap("theme:cardback");
+        QPixmap tmpPixmap = themePixmap(QStringLiteral("cardback"));
 
         if (tmpPixmap.isNull()) {
             qCWarning(CardPictureLoaderLog) << "Failed to load 'theme:cardback' for in-progress state! Using fallback.";
@@ -105,7 +106,7 @@ void CardPictureLoader::getCardBackLoadingFailedPixmap(QPixmap &pixmap, QSize si
         "_trice_card_back_failed_" + QString::number(size.width()) + "x" + QString::number(size.height());
     if (!QPixmapCache::find(backCacheKey, &pixmap)) {
         qCDebug(CardPictureLoaderCardBackCacheFailLog) << "PictureLoader: cache miss for" << backCacheKey;
-        QPixmap tmpPixmap("theme:cardback");
+        QPixmap tmpPixmap = themePixmap(QStringLiteral("cardback"));
 
         if (tmpPixmap.isNull()) {
             qCWarning(CardPictureLoaderLog) << "Failed to load 'theme:cardback' for failed state! Using fallback.";

--- a/cockatrice/src/interface/widgets/deck_analytics/abstract_analytics_panel_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_analytics/abstract_analytics_panel_widget.cpp
@@ -1,5 +1,6 @@
 #include "abstract_analytics_panel_widget.h"
 
+#include "../../pixel_map_generator.h"
 #include "deck_list_statistics_analyzer.h"
 
 #include <QPushButton>
@@ -20,7 +21,7 @@ AbstractAnalyticsPanelWidget::AbstractAnalyticsPanelWidget(QWidget *parent, Deck
 
     // config button
     configureButton = new QPushButton(this);
-    configureButton->setIcon(QPixmap("theme:icons/cogwheel"));
+    configureButton->setIcon(themePixmap(QStringLiteral("icons/cogwheel")));
     configureButton->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
     connect(configureButton, &QPushButton::clicked, this, &AbstractAnalyticsPanelWidget::applyConfigFromDialog);
     bannerAndSettingsLayout->addWidget(configureButton, 0);

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_database_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_database_display_widget.cpp
@@ -28,7 +28,7 @@ DeckEditorDatabaseDisplayWidget::DeckEditorDatabaseDisplayWidget(QWidget *parent
     searchEdit->setPlaceholderText(tr("Search by card name (or search expressions)"));
     searchEdit->setClearButtonEnabled(true);
     searchEdit->addAction(loadColorAdjustedPixmap("theme:icons/search"), QLineEdit::LeadingPosition);
-    auto help = searchEdit->addAction(QPixmap("theme:icons/info"), QLineEdit::TrailingPosition);
+    auto help = searchEdit->addAction(themePixmap(QStringLiteral("icons/info")), QLineEdit::TrailingPosition);
 
     setFocusProxy(searchEdit);
     setFocusPolicy(Qt::ClickFocus);
@@ -59,13 +59,13 @@ DeckEditorDatabaseDisplayWidget::DeckEditorDatabaseDisplayWidget(QWidget *parent
             &DeckEditorDatabaseDisplayWidget::onRelatedCardClicked);
 
     aAddCard = new QAction(QString(), this);
-    aAddCard->setIcon(QPixmap("theme:icons/arrow_right_green"));
+    aAddCard->setIcon(themePixmap(QStringLiteral("icons/arrow_right_green")));
     connect(aAddCard, &QAction::triggered, this, &DeckEditorDatabaseDisplayWidget::actAddCardToMainDeck);
     auto *tbAddCard = new QToolButton(this);
     tbAddCard->setDefaultAction(aAddCard);
 
     aAddCardToSideboard = new QAction(QString(), this);
-    aAddCardToSideboard->setIcon(QPixmap("theme:icons/arrow_right_blue"));
+    aAddCardToSideboard->setIcon(themePixmap(QStringLiteral("icons/arrow_right_blue")));
     connect(aAddCardToSideboard, &QAction::triggered, this, &DeckEditorDatabaseDisplayWidget::actAddCardToSideboard);
     auto *tbAddCardToSideboard = new QToolButton(this);
     tbAddCardToSideboard->setDefaultAction(aAddCardToSideboard);

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_deck_dock_widget.cpp
@@ -2,6 +2,7 @@
 
 #include "../../../client/settings/cache_settings.h"
 #include "../../../client/settings/shortcuts_settings.h"
+#include "../../pixel_map_generator.h"
 #include "../playmat/playmat_settings_dialog.h"
 #include "../settings_page/user_interface_settings_page.h"
 #include "../tabs/api/commander_spellbook/commander_bracket_widget.h"
@@ -192,25 +193,25 @@ void DeckEditorDeckDockWidget::createDeckDock()
             &DeckEditorDeckDockWidget::applyActiveGroupCriteria);
 
     aIncrement = new QAction(QString(), this);
-    aIncrement->setIcon(QPixmap("theme:icons/increment"));
+    aIncrement->setIcon(themePixmap(QStringLiteral("icons/increment")));
     connect(aIncrement, &QAction::triggered, this, &DeckEditorDeckDockWidget::actIncrementSelection);
     auto *tbIncrement = new QToolButton(this);
     tbIncrement->setDefaultAction(aIncrement);
 
     aDecrement = new QAction(QString(), this);
-    aDecrement->setIcon(QPixmap("theme:icons/decrement"));
+    aDecrement->setIcon(themePixmap(QStringLiteral("icons/decrement")));
     connect(aDecrement, &QAction::triggered, this, &DeckEditorDeckDockWidget::actDecrementSelection);
     auto *tbDecrement = new QToolButton(this);
     tbDecrement->setDefaultAction(aDecrement);
 
     aRemoveCard = new QAction(QString(), this);
-    aRemoveCard->setIcon(QPixmap("theme:icons/remove_row"));
+    aRemoveCard->setIcon(themePixmap(QStringLiteral("icons/remove_row")));
     connect(aRemoveCard, &QAction::triggered, this, &DeckEditorDeckDockWidget::actRemoveCard);
     auto *tbRemoveCard = new QToolButton(this);
     tbRemoveCard->setDefaultAction(aRemoveCard);
 
     aSwapCard = new QAction(QString(), this);
-    aSwapCard->setIcon(QPixmap("theme:icons/swap"));
+    aSwapCard->setIcon(themePixmap(QStringLiteral("icons/swap")));
     connect(aSwapCard, &QAction::triggered, this, &DeckEditorDeckDockWidget::actSwapSelection);
     auto *tbSwapCard = new QToolButton(this);
     tbSwapCard->setDefaultAction(aSwapCard);

--- a/cockatrice/src/interface/widgets/deck_editor/deck_editor_filter_dock_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_editor_filter_dock_widget.cpp
@@ -4,6 +4,7 @@
 #include "../../../client/settings/shortcuts_settings.h"
 #include "../../../filters/filter_builder.h"
 #include "../../../filters/filter_tree_model.h"
+#include "../../pixel_map_generator.h"
 
 #include <QGridLayout>
 #include <QMenu>
@@ -42,11 +43,11 @@ void DeckEditorFilterDockWidget::createFiltersDock()
     connect(filterBuilder, &FilterBuilder::add, filterModel, &FilterTreeModel::addFilter);
 
     aClearFilterOne = new QAction(QString(), this);
-    aClearFilterOne->setIcon(QPixmap("theme:icons/decrement"));
+    aClearFilterOne->setIcon(themePixmap(QStringLiteral("icons/decrement")));
     connect(aClearFilterOne, &QAction::triggered, this, &DeckEditorFilterDockWidget::actClearFilterOne);
 
     aClearFilterAll = new QAction(QString(), this);
-    aClearFilterAll->setIcon(QPixmap("theme:icons/clearsearch"));
+    aClearFilterAll->setIcon(themePixmap(QStringLiteral("icons/clearsearch")));
     connect(aClearFilterAll, &QAction::triggered, this, &DeckEditorFilterDockWidget::actClearFilterAll);
 
     auto *filterDelOne = new QToolButton();

--- a/cockatrice/src/interface/widgets/deck_editor/deck_list_history_manager_widget.cpp
+++ b/cockatrice/src/interface/widgets/deck_editor/deck_list_history_manager_widget.cpp
@@ -1,5 +1,6 @@
 #include "deck_list_history_manager_widget.h"
 
+#include "../../pixel_map_generator.h"
 #include "deck_state_manager.h"
 
 DeckListHistoryManagerWidget::DeckListHistoryManagerWidget(DeckStateManager *_deckStateManager,
@@ -10,7 +11,7 @@ DeckListHistoryManagerWidget::DeckListHistoryManagerWidget(DeckStateManager *_de
     layout = new QHBoxLayout(this);
 
     aUndo = new QAction(QString(), this);
-    aUndo->setIcon(QPixmap("theme:icons/arrow_undo"));
+    aUndo->setIcon(themePixmap(QStringLiteral("icons/arrow_undo")));
     aUndo->setShortcut(QKeySequence::Undo);
     aUndo->setShortcutContext(Qt::ApplicationShortcut);
     connect(aUndo, &QAction::triggered, this, &DeckListHistoryManagerWidget::doUndo);
@@ -19,7 +20,7 @@ DeckListHistoryManagerWidget::DeckListHistoryManagerWidget(DeckStateManager *_de
     undoButton->setDefaultAction(aUndo);
 
     aRedo = new QAction(QString(), this);
-    aRedo->setIcon(QPixmap("theme:icons/arrow_redo"));
+    aRedo->setIcon(themePixmap(QStringLiteral("icons/arrow_redo")));
     aRedo->setShortcut(QKeySequence::Redo);
     aRedo->setShortcutContext(Qt::ApplicationShortcut);
     connect(aRedo, &QAction::triggered, this, &DeckListHistoryManagerWidget::doRedo);
@@ -31,7 +32,7 @@ DeckListHistoryManagerWidget::DeckListHistoryManagerWidget(DeckStateManager *_de
     layout->addWidget(redoButton);
 
     historyButton = new SettingsButtonWidget(this);
-    historyButton->setButtonIcon(QPixmap("theme:icons/arrow_history"));
+    historyButton->setButtonIcon(themePixmap(QStringLiteral("icons/arrow_history")));
 
     historyLabel = new QLabel(this);
 

--- a/cockatrice/src/interface/widgets/dialogs/dlg_connect.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_connect.cpp
@@ -1,6 +1,7 @@
 #include "dlg_connect.h"
 
 #include "../../../client/settings/cache_settings.h"
+#include "../../pixel_map_generator.h"
 
 #include <QCheckBox>
 #include <QComboBox>
@@ -21,7 +22,7 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     previousHosts = new QComboBox(this);
 
     btnDeleteServer = new QPushButton(this);
-    btnDeleteServer->setIcon(QPixmap("theme:icons/remove_row"));
+    btnDeleteServer->setIcon(themePixmap(QStringLiteral("icons/remove_row")));
     btnDeleteServer->setToolTip(tr("Delete the currently selected saved server"));
     btnDeleteServer->setFixedWidth(30);
 
@@ -29,7 +30,7 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
 
     hps = new HandlePublicServers(this);
     btnRefreshServers = new QPushButton(this);
-    btnRefreshServers->setIcon(QPixmap("theme:icons/sync"));
+    btnRefreshServers->setIcon(themePixmap(QStringLiteral("icons/sync")));
     btnRefreshServers->setToolTip(tr("Refresh the server list with known public servers"));
     btnRefreshServers->setFixedWidth(30);
 
@@ -99,7 +100,7 @@ DlgConnect::DlgConnect(QWidget *parent) : QDialog(parent)
     updateDisplayInfo(previousHosts->currentText());
 
     btnForgotPassword = new QPushButton(this);
-    btnForgotPassword->setIcon(QPixmap("theme:icons/forgot_password"));
+    btnForgotPassword->setIcon(themePixmap(QStringLiteral("icons/forgot_password")));
     btnForgotPassword->setToolTip(tr("Reset Password"));
     btnForgotPassword->setFixedWidth(30);
     connect(btnForgotPassword, &QPushButton::released, this, &DlgConnect::actForgotPassword);

--- a/cockatrice/src/interface/widgets/dialogs/dlg_edit_tokens.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_edit_tokens.cpp
@@ -1,5 +1,6 @@
 #include "dlg_edit_tokens.h"
 
+#include "../../pixel_map_generator.h"
 #include "../interface/widgets/utility/get_text_with_max.h"
 
 #include <QAction>
@@ -90,10 +91,10 @@ DlgEditTokens::DlgEditTokens(QWidget *parent) : QDialog(parent), currentCard(nul
             &DlgEditTokens::tokenSelectionChanged);
 
     QAction *aAddToken = new QAction(tr("Add token"), this);
-    aAddToken->setIcon(QPixmap("theme:icons/increment"));
+    aAddToken->setIcon(themePixmap(QStringLiteral("icons/increment")));
     connect(aAddToken, &QAction::triggered, this, &DlgEditTokens::actAddToken);
     QAction *aRemoveToken = new QAction(tr("Remove token"), this);
-    aRemoveToken->setIcon(QPixmap("theme:icons/decrement"));
+    aRemoveToken->setIcon(themePixmap(QStringLiteral("icons/decrement")));
     connect(aRemoveToken, &QAction::triggered, this, &DlgEditTokens::actRemoveToken);
 
     auto *databaseToolBar = new QToolBar;

--- a/cockatrice/src/interface/widgets/dialogs/dlg_manage_sets.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_manage_sets.cpp
@@ -1,6 +1,7 @@
 #include "dlg_manage_sets.h"
 
 #include "../../../client/settings/cache_settings.h"
+#include "../../pixel_map_generator.h"
 #include "../interface/card_picture_loader/card_picture_loader.h"
 #include "../interface/widgets/utility/custom_line_edit.h"
 
@@ -35,28 +36,28 @@ WndSets::WndSets(QWidget *parent) : QMainWindow(parent)
     setsEditToolBar->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
 
     aTop = new QAction(QString(), this);
-    aTop->setIcon(QPixmap("theme:icons/arrow_top_green"));
+    aTop->setIcon(themePixmap(QStringLiteral("icons/arrow_top_green")));
     aTop->setToolTip(tr("Move selected set to the top"));
     aTop->setEnabled(false);
     connect(aTop, &QAction::triggered, this, &WndSets::actTop);
     setsEditToolBar->addAction(aTop);
 
     aUp = new QAction(QString(), this);
-    aUp->setIcon(QPixmap("theme:icons/arrow_up_green"));
+    aUp->setIcon(themePixmap(QStringLiteral("icons/arrow_up_green")));
     aUp->setToolTip(tr("Move selected set up"));
     aUp->setEnabled(false);
     connect(aUp, &QAction::triggered, this, &WndSets::actUp);
     setsEditToolBar->addAction(aUp);
 
     aDown = new QAction(QString(), this);
-    aDown->setIcon(QPixmap("theme:icons/arrow_down_green"));
+    aDown->setIcon(themePixmap(QStringLiteral("icons/arrow_down_green")));
     aDown->setToolTip(tr("Move selected set down"));
     aDown->setEnabled(false);
     connect(aDown, &QAction::triggered, this, &WndSets::actDown);
     setsEditToolBar->addAction(aDown);
 
     aBottom = new QAction(QString(), this);
-    aBottom->setIcon(QPixmap("theme:icons/arrow_bottom_green"));
+    aBottom->setIcon(themePixmap(QStringLiteral("icons/arrow_bottom_green")));
     aBottom->setToolTip(tr("Move selected set to the bottom"));
     aBottom->setEnabled(false);
     connect(aBottom, &QAction::triggered, this, &WndSets::actBottom);
@@ -66,7 +67,7 @@ WndSets::WndSets(QWidget *parent) : QMainWindow(parent)
     searchField = new LineEditUnfocusable;
     searchField->setObjectName("searchEdit");
     searchField->setPlaceholderText(tr("Search by set name, code, type, or release date"));
-    searchField->addAction(QPixmap("theme:icons/search"), LineEditUnfocusable::LeadingPosition);
+    searchField->addAction(themePixmap(QStringLiteral("icons/search")), LineEditUnfocusable::LeadingPosition);
     searchField->setClearButtonEnabled(true);
     setFocusProxy(searchField);
 

--- a/cockatrice/src/interface/widgets/dialogs/dlg_register.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_register.cpp
@@ -1,6 +1,7 @@
 #include "dlg_register.h"
 
 #include "../../../client/settings/cache_settings.h"
+#include "../../pixel_map_generator.h"
 #include "../server/handle_public_servers.h"
 #include "../server/user/user_info_connection.h"
 
@@ -24,7 +25,7 @@ DlgRegister::DlgRegister(QWidget *parent) : QDialog(parent)
     previousHosts = new QComboBox(this);
 
     btnDeleteServer = new QPushButton(this);
-    btnDeleteServer->setIcon(QPixmap("theme:icons/remove_row"));
+    btnDeleteServer->setIcon(themePixmap(QStringLiteral("icons/remove_row")));
     btnDeleteServer->setToolTip(tr("Delete the currently selected saved server"));
     btnDeleteServer->setFixedWidth(30);
 
@@ -32,7 +33,7 @@ DlgRegister::DlgRegister(QWidget *parent) : QDialog(parent)
 
     hps = new HandlePublicServers(this);
     btnRefreshServers = new QPushButton(this);
-    btnRefreshServers->setIcon(QPixmap("theme:icons/sync"));
+    btnRefreshServers->setIcon(themePixmap(QStringLiteral("icons/sync")));
     btnRefreshServers->setToolTip(tr("Refresh the server list with known public servers"));
     btnRefreshServers->setFixedWidth(30);
 

--- a/cockatrice/src/interface/widgets/dialogs/dlg_settings.cpp
+++ b/cockatrice/src/interface/widgets/dialogs/dlg_settings.cpp
@@ -6,6 +6,7 @@
 #include "dlg_settings.h"
 
 #include "../../../client/settings/cache_settings.h"
+#include "../../pixel_map_generator.h"
 #include "../main.h"
 #include "../settings_page/appearance_settings_page.h"
 #include "../settings_page/deck_editor_settings_page.h"
@@ -96,7 +97,7 @@ void DlgSettings::setupUi()
     // Search bar
     searchEdit = new QLineEdit;
     searchEdit->setClearButtonEnabled(true);
-    searchEdit->addAction(QPixmap("theme:icons/search"), QLineEdit::LeadingPosition);
+    searchEdit->addAction(themePixmap(QStringLiteral("icons/search")), QLineEdit::LeadingPosition);
     searchEdit->installEventFilter(this);
     connect(searchEdit, &QLineEdit::textChanged, this, &DlgSettings::onSearchTextChanged);
 

--- a/cockatrice/src/interface/widgets/quick_settings/settings_button_widget.cpp
+++ b/cockatrice/src/interface/widgets/quick_settings/settings_button_widget.cpp
@@ -1,5 +1,7 @@
 #include "settings_button_widget.h"
 
+#include "../../pixel_map_generator.h"
+
 #include <QApplication>
 #include <QHBoxLayout>
 #include <QMouseEvent>
@@ -8,7 +10,7 @@
 SettingsButtonWidget::SettingsButtonWidget(QWidget *parent)
     : QWidget(parent), button(new QToolButton(this)), popup(new SettingsPopupWidget(nullptr))
 {
-    button->setIcon(QPixmap("theme:icons/cogwheel"));
+    button->setIcon(themePixmap(QStringLiteral("icons/cogwheel")));
     button->setCheckable(true);
     button->setFixedSize(32, 32);
     connect(button, &QToolButton::clicked, this, &SettingsButtonWidget::togglePopup);

--- a/cockatrice/src/interface/widgets/replay/replay_widget.cpp
+++ b/cockatrice/src/interface/widgets/replay/replay_widget.cpp
@@ -2,6 +2,7 @@
 
 #include "../../../client/settings/cache_settings.h"
 #include "../../../client/settings/shortcuts_settings.h"
+#include "../../pixel_map_generator.h"
 #include "../interface/widgets/tabs/tab_game.h"
 #include "replay_manager.h"
 #include "replay_quick_settings_widget.h"
@@ -50,15 +51,15 @@ ReplayWidget::ReplayWidget(QWidget *parent, GameReplay *replay)
     replayPlayButton = new QToolButton;
     replayPlayButton->setIconSize(QSize(32, 32));
     QIcon playButtonIcon = QIcon();
-    playButtonIcon.addPixmap(QPixmap("theme:replay/start"), QIcon::Normal, QIcon::Off);
-    playButtonIcon.addPixmap(QPixmap("theme:replay/pause"), QIcon::Normal, QIcon::On);
+    playButtonIcon.addPixmap(themePixmap(QStringLiteral("replay/start")), QIcon::Normal, QIcon::Off);
+    playButtonIcon.addPixmap(themePixmap(QStringLiteral("replay/pause")), QIcon::Normal, QIcon::On);
     replayPlayButton->setIcon(playButtonIcon);
     replayPlayButton->setCheckable(true);
     connect(replayPlayButton, &QToolButton::toggled, this, &ReplayWidget::replayPlayButtonToggled);
 
     replayFastForwardButton = new QToolButton;
     replayFastForwardButton->setIconSize(QSize(32, 32));
-    replayFastForwardButton->setIcon(QPixmap("theme:replay/fastforward"));
+    replayFastForwardButton->setIcon(themePixmap(QStringLiteral("replay/fastforward")));
     replayFastForwardButton->setCheckable(true);
     connect(replayFastForwardButton, &QToolButton::toggled, this, &ReplayWidget::updateTimeScaleFactor);
 

--- a/cockatrice/src/interface/widgets/server/game_selector.cpp
+++ b/cockatrice/src/interface/widgets/server/game_selector.cpp
@@ -1,5 +1,6 @@
 #include "game_selector.h"
 
+#include "../../pixel_map_generator.h"
 #include "../interface/widgets/dialogs/dlg_create_game.h"
 #include "../interface/widgets/dialogs/dlg_filter_games.h"
 #include "../interface/widgets/tabs/tab_account.h"
@@ -95,10 +96,10 @@ GameSelector::GameSelector(AbstractClient *_client,
     }
 
     filterButton = new QPushButton;
-    filterButton->setIcon(QPixmap("theme:icons/search"));
+    filterButton->setIcon(themePixmap(QStringLiteral("icons/search")));
     connect(filterButton, &QPushButton::clicked, this, &GameSelector::actSetFilter);
     clearFilterButton = new QPushButton;
-    clearFilterButton->setIcon(QPixmap("theme:icons/clearsearch"));
+    clearFilterButton->setIcon(themePixmap(QStringLiteral("icons/clearsearch")));
     bool filtersSetToDefault = showFilters && gameListProxyModel->areFilterParametersSetToDefaults();
     clearFilterButton->setEnabled(!filtersSetToDefault);
     connect(clearFilterButton, &QPushButton::clicked, this, &GameSelector::actClearFilter);

--- a/cockatrice/src/interface/widgets/server/remote/remote_replay_list_tree_widget.cpp
+++ b/cockatrice/src/interface/widgets/server/remote/remote_replay_list_tree_widget.cpp
@@ -1,5 +1,7 @@
 #include "remote_replay_list_tree_widget.h"
 
+#include "../../../pixel_map_generator.h"
+
 #include <QFileIconProvider>
 #include <QHeaderView>
 #include <QSortFilterProxyModel>
@@ -37,7 +39,7 @@ RemoteReplayList_TreeModel::RemoteReplayList_TreeModel(AbstractClient *_client, 
     QFileIconProvider fip;
     dirIcon = fip.icon(QFileIconProvider::Folder);
     fileIcon = fip.icon(QFileIconProvider::File);
-    lockIcon = QPixmap("theme:icons/lock");
+    lockIcon = themePixmap(QStringLiteral("icons/lock"));
 }
 
 RemoteReplayList_TreeModel::~RemoteReplayList_TreeModel()

--- a/cockatrice/src/interface/widgets/settings_page/deck_editor_settings_page.cpp
+++ b/cockatrice/src/interface/widgets/settings_page/deck_editor_settings_page.cpp
@@ -1,6 +1,7 @@
 #include "deck_editor_settings_page.h"
 
 #include "../../../client/settings/cache_settings.h"
+#include "../../pixel_map_generator.h"
 #include "update/card_spoiler/spoiler_background_updater.h"
 
 #include <QFileDialog>
@@ -53,15 +54,15 @@ DeckEditorSettingsPage::DeckEditorSettingsPage()
     urlList->addItems(SettingsCache::instance().downloads().getAllURLs());
 
     aAdd = new QAction(this);
-    aAdd->setIcon(QPixmap("theme:icons/increment"));
+    aAdd->setIcon(themePixmap(QStringLiteral("icons/increment")));
     connect(aAdd, &QAction::triggered, this, &DeckEditorSettingsPage::actAddURL);
 
     aEdit = new QAction(this);
-    aEdit->setIcon(QPixmap("theme:icons/pencil"));
+    aEdit->setIcon(themePixmap(QStringLiteral("icons/pencil")));
     connect(aEdit, &QAction::triggered, this, &DeckEditorSettingsPage::actEditURL);
 
     aRemove = new QAction(this);
-    aRemove->setIcon(QPixmap("theme:icons/decrement"));
+    aRemove->setIcon(themePixmap(QStringLiteral("icons/decrement")));
     connect(aRemove, &QAction::triggered, this, &DeckEditorSettingsPage::actRemoveURL);
 
     auto *urlToolBar = new QToolBar;

--- a/cockatrice/src/interface/widgets/settings_page/messages_settings_page.cpp
+++ b/cockatrice/src/interface/widgets/settings_page/messages_settings_page.cpp
@@ -1,6 +1,7 @@
 #include "messages_settings_page.h"
 
 #include "../../../client/settings/cache_settings.h"
+#include "../../pixel_map_generator.h"
 #include "../interface/widgets/utility/get_text_with_max.h"
 
 #include <QGridLayout>
@@ -107,15 +108,15 @@ MessagesSettingsPage::MessagesSettingsPage()
     }
 
     aAdd = new QAction(this);
-    aAdd->setIcon(QPixmap("theme:icons/increment"));
+    aAdd->setIcon(themePixmap(QStringLiteral("icons/increment")));
     connect(aAdd, &QAction::triggered, this, &MessagesSettingsPage::actAdd);
 
     aEdit = new QAction(this);
-    aEdit->setIcon(QPixmap("theme:icons/pencil"));
+    aEdit->setIcon(themePixmap(QStringLiteral("icons/pencil")));
     connect(aEdit, &QAction::triggered, this, &MessagesSettingsPage::actEdit);
 
     aRemove = new QAction(this);
-    aRemove->setIcon(QPixmap("theme:icons/decrement"));
+    aRemove->setIcon(themePixmap(QStringLiteral("icons/decrement")));
     connect(aRemove, &QAction::triggered, this, &MessagesSettingsPage::actRemove);
 
     auto *messageToolBar = new QToolBar;

--- a/cockatrice/src/interface/widgets/settings_page/shortcut_settings_page.cpp
+++ b/cockatrice/src/interface/widgets/settings_page/shortcut_settings_page.cpp
@@ -3,6 +3,7 @@
 #include "../../../client/settings/cache_settings.h"
 #include "../../../client/settings/shortcut_treeview.h"
 #include "../../../client/settings/shortcuts_settings.h"
+#include "../../pixel_map_generator.h"
 #include "../interface/widgets/utility/custom_line_edit.h"
 #include "../interface/widgets/utility/sequence_edit.h"
 
@@ -47,8 +48,8 @@ ShortcutSettingsPage::ShortcutSettingsPage()
     btnResetAll = new QPushButton(this);
     btnClearAll = new QPushButton(this);
 
-    btnResetAll->setIcon(QPixmap("theme:icons/update"));
-    btnClearAll->setIcon(QPixmap("theme:icons/clearsearch"));
+    btnResetAll->setIcon(themePixmap(QStringLiteral("icons/update")));
+    btnClearAll->setIcon(themePixmap(QStringLiteral("icons/clearsearch")));
 
     // layout
     auto *_editLayout = new QGridLayout;

--- a/cockatrice/src/interface/widgets/tabs/api/archidekt/tab_archidekt.cpp
+++ b/cockatrice/src/interface/widgets/tabs/api/archidekt/tab_archidekt.cpp
@@ -1,6 +1,7 @@
 #include "tab_archidekt.h"
 
 #include "../../../../../client/settings/cache_settings.h"
+#include "../../../../pixel_map_generator.h"
 #include "../../../cards/additional_info/mana_symbol_widget.h"
 #include "../../../utility/completer_utils.h"
 #include "../../tab_supervisor.h"
@@ -213,7 +214,7 @@ void TabArchidekt::setupFilterWidgets()
     // Format filter (collapsible)
     formatButton = new SettingsButtonWidget(secondaryToolbar);
     formatButton->setButtonText(tr("Formats"));
-    formatButton->setButtonIcon(QPixmap("theme:icons/scale_balanced"));
+    formatButton->setButtonIcon(themePixmap(QStringLiteral("icons/scale_balanced")));
 
     QWidget *formatContainer = new QWidget(secondaryToolbar);
     QGridLayout *formatLayout = new QGridLayout(formatContainer);

--- a/cockatrice/src/interface/widgets/tabs/api/commander_spellbook/commander_bracket_widget.cpp
+++ b/cockatrice/src/interface/widgets/tabs/api/commander_spellbook/commander_bracket_widget.cpp
@@ -1,6 +1,7 @@
 #include "commander_bracket_widget.h"
 
 #include "../../../../../client/settings/cache_settings.h"
+#include "../../../../pixel_map_generator.h"
 #include "commander_bracket_service.h"
 
 #include <QComboBox>
@@ -30,7 +31,7 @@ CommanderBracketWidget::CommanderBracketWidget(QWidget *parent) : QWidget(parent
     bracketInfoButton->setEnabled(false);
 
     bracketRefreshButton = new QToolButton(this);
-    bracketRefreshButton->setIcon(QPixmap("theme:icons/reload"));
+    bracketRefreshButton->setIcon(themePixmap(QStringLiteral("icons/reload")));
     bracketRefreshButton->setAutoRaise(true);
 
     connect(bracketRefreshButton, &QToolButton::clicked, this, &CommanderBracketWidget::requestBracketEstimate);

--- a/cockatrice/src/interface/widgets/tabs/tab_deck_storage.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_deck_storage.cpp
@@ -2,6 +2,7 @@
 
 #include "../../../client/settings/cache_settings.h"
 #include "../../deck_loader/deck_loader.h"
+#include "../../pixel_map_generator.h"
 #include "../interface/widgets/server/remote/remote_decklist_tree_widget.h"
 #include "../interface/widgets/utility/get_text_with_max.h"
 
@@ -105,19 +106,19 @@ TabDeckStorage::TabDeckStorage(TabSupervisor *_tabSupervisor,
 
     // Left side actions
     aOpenLocalDeck = new QAction(this);
-    aOpenLocalDeck->setIcon(QPixmap("theme:icons/pencil"));
+    aOpenLocalDeck->setIcon(themePixmap(QStringLiteral("icons/pencil")));
     connect(aOpenLocalDeck, &QAction::triggered, this, &TabDeckStorage::actOpenLocalDeck);
     aRenameLocal = new QAction(this);
-    aRenameLocal->setIcon(QPixmap("theme:icons/rename"));
+    aRenameLocal->setIcon(themePixmap(QStringLiteral("icons/rename")));
     connect(aRenameLocal, &QAction::triggered, this, &TabDeckStorage::actRenameLocal);
     aUpload = new QAction(this);
-    aUpload->setIcon(QPixmap("theme:icons/arrow_right_green"));
+    aUpload->setIcon(themePixmap(QStringLiteral("icons/arrow_right_green")));
     connect(aUpload, &QAction::triggered, this, &TabDeckStorage::actUpload);
     aNewLocalFolder = new QAction(this);
     aNewLocalFolder->setIcon(qApp->style()->standardIcon(QStyle::SP_FileDialogNewFolder));
     connect(aNewLocalFolder, &QAction::triggered, this, &TabDeckStorage::actNewLocalFolder);
     aDeleteLocalDeck = new QAction(this);
-    aDeleteLocalDeck->setIcon(QPixmap("theme:icons/remove_row"));
+    aDeleteLocalDeck->setIcon(themePixmap(QStringLiteral("icons/remove_row")));
     connect(aDeleteLocalDeck, &QAction::triggered, this, &TabDeckStorage::actDeleteLocalDeck);
 
     aOpenDecksFolder = new QAction(this);
@@ -126,16 +127,16 @@ TabDeckStorage::TabDeckStorage(TabSupervisor *_tabSupervisor,
 
     // Right side actions
     aOpenRemoteDeck = new QAction(this);
-    aOpenRemoteDeck->setIcon(QPixmap("theme:icons/pencil"));
+    aOpenRemoteDeck->setIcon(themePixmap(QStringLiteral("icons/pencil")));
     connect(aOpenRemoteDeck, &QAction::triggered, this, &TabDeckStorage::actOpenRemoteDeck);
     aDownload = new QAction(this);
-    aDownload->setIcon(QPixmap("theme:icons/arrow_left_green"));
+    aDownload->setIcon(themePixmap(QStringLiteral("icons/arrow_left_green")));
     connect(aDownload, &QAction::triggered, this, &TabDeckStorage::actDownload);
     aNewFolder = new QAction(this);
     aNewFolder->setIcon(qApp->style()->standardIcon(QStyle::SP_FileDialogNewFolder));
     connect(aNewFolder, &QAction::triggered, this, &TabDeckStorage::actNewFolder);
     aDeleteRemoteDeck = new QAction(this);
-    aDeleteRemoteDeck->setIcon(QPixmap("theme:icons/remove_row"));
+    aDeleteRemoteDeck->setIcon(themePixmap(QStringLiteral("icons/remove_row")));
     connect(aDeleteRemoteDeck, &QAction::triggered, this, &TabDeckStorage::actDeleteRemoteDeck);
 
     // Add actions to toolbars

--- a/cockatrice/src/interface/widgets/tabs/tab_replays.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_replays.cpp
@@ -1,6 +1,7 @@
 #include "tab_replays.h"
 
 #include "../../../client/settings/cache_settings.h"
+#include "../../pixel_map_generator.h"
 #include "../interface/widgets/server/remote/remote_replay_list_tree_widget.h"
 #include "tab_game.h"
 
@@ -102,17 +103,17 @@ QGroupBox *TabReplays::createLeftLayout()
 
     // Left side actions
     aOpenLocalReplay = new QAction(this);
-    aOpenLocalReplay->setIcon(QPixmap("theme:icons/view"));
+    aOpenLocalReplay->setIcon(themePixmap(QStringLiteral("icons/view")));
     connect(aOpenLocalReplay, &QAction::triggered, this, &TabReplays::actOpenLocalReplay);
     connect(localDirView, &QTreeView::doubleClicked, this, &TabReplays::actOpenLocalReplay);
     aRenameLocal = new QAction(this);
-    aRenameLocal->setIcon(QPixmap("theme:icons/rename"));
+    aRenameLocal->setIcon(themePixmap(QStringLiteral("icons/rename")));
     connect(aRenameLocal, &QAction::triggered, this, &TabReplays::actRenameLocal);
     aNewLocalFolder = new QAction(this);
     aNewLocalFolder->setIcon(qApp->style()->standardIcon(QStyle::SP_FileDialogNewFolder));
     connect(aNewLocalFolder, &QAction::triggered, this, &TabReplays::actNewLocalFolder);
     aDeleteLocalReplay = new QAction(this);
-    aDeleteLocalReplay->setIcon(QPixmap("theme:icons/remove_row"));
+    aDeleteLocalReplay->setIcon(themePixmap(QStringLiteral("icons/remove_row")));
     connect(aDeleteLocalReplay, &QAction::triggered, this, &TabReplays::actDeleteLocalReplay);
 
     aOpenReplaysFolder = new QAction(this);
@@ -164,24 +165,24 @@ QGroupBox *TabReplays::createRightLayout()
 
     // Right side actions
     aOpenRemoteReplay = new QAction(this);
-    aOpenRemoteReplay->setIcon(QPixmap("theme:icons/view"));
+    aOpenRemoteReplay->setIcon(themePixmap(QStringLiteral("icons/view")));
     connect(aOpenRemoteReplay, &QAction::triggered, this, &TabReplays::actOpenRemoteReplay);
     connect(serverDirView, &QTreeView::doubleClicked, this, &TabReplays::actOpenRemoteReplay);
     aDownload = new QAction(this);
-    aDownload->setIcon(QPixmap("theme:icons/arrow_left_green"));
+    aDownload->setIcon(themePixmap(QStringLiteral("icons/arrow_left_green")));
     connect(aDownload, &QAction::triggered, this, &TabReplays::actDownload);
     aKeep = new QAction(this);
-    aKeep->setIcon(QPixmap("theme:icons/lock"));
+    aKeep->setIcon(themePixmap(QStringLiteral("icons/lock")));
     connect(aKeep, &QAction::triggered, this, &TabReplays::actKeepRemoteReplay);
     aDeleteRemoteReplay = new QAction(this);
-    aDeleteRemoteReplay->setIcon(QPixmap("theme:icons/remove_row"));
+    aDeleteRemoteReplay->setIcon(themePixmap(QStringLiteral("icons/remove_row")));
     connect(aDeleteRemoteReplay, &QAction::triggered, this, &TabReplays::actDeleteRemoteReplay);
     aGetReplayCode = new QAction(this);
-    aGetReplayCode->setIcon(QPixmap("theme:icons/share"));
+    aGetReplayCode->setIcon(themePixmap(QStringLiteral("icons/share")));
     connect(aGetReplayCode, &QAction::triggered, this, &TabReplays::actGetReplayCode);
 
     aSubmitReplayCode = new QAction(this);
-    aSubmitReplayCode->setIcon(QPixmap("theme:icons/search"));
+    aSubmitReplayCode->setIcon(themePixmap(QStringLiteral("icons/search")));
     connect(aSubmitReplayCode, &QAction::triggered, this, &TabReplays::actSubmitReplayCode);
 
     // Add actions to toolbars

--- a/cockatrice/src/interface/widgets/tabs/tab_room.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_room.cpp
@@ -2,6 +2,7 @@
 
 #include "../../../client/settings/cache_settings.h"
 #include "../../../client/settings/shortcuts_settings.h"
+#include "../../pixel_map_generator.h"
 #include "../interface/widgets/dialogs/dlg_settings.h"
 #include "../interface/widgets/server/chat_view/chat_view.h"
 #include "../interface/widgets/server/game_link.h"
@@ -98,7 +99,7 @@ TabRoom::TabRoom(TabSupervisor *_tabSupervisor,
     connect(aOpenChatSettings, &QAction::triggered, this, &TabRoom::actOpenChatSettings);
 
     auto *chatSettingsButton = new QToolButton;
-    chatSettingsButton->setIcon(QPixmap("theme:icons/settings"));
+    chatSettingsButton->setIcon(themePixmap(QStringLiteral("icons/settings")));
     chatSettingsButton->setMenu(chatSettingsMenu);
     chatSettingsButton->setPopupMode(QToolButton::InstantPopup);
 

--- a/cockatrice/src/interface/widgets/tabs/tab_supervisor.cpp
+++ b/cockatrice/src/interface/widgets/tabs/tab_supervisor.cpp
@@ -1249,7 +1249,7 @@ void TabSupervisor::tabUserEvent(bool globalEvent)
     auto *tab = static_cast<Tab *>(sender());
     if (tab != currentWidget()) {
         tab->setContentsChanged(true);
-        setTabIcon(indexOf(tab), QPixmap("theme:icons/tab_changed"));
+        setTabIcon(indexOf(tab), themePixmap(QStringLiteral("icons/tab_changed")));
     }
     if (globalEvent && SettingsCache::instance().userInterface().getNotificationsEnabled()) {
         QApplication::alert(this);

--- a/cockatrice/src/interface/widgets/utility/sequence_edit.cpp
+++ b/cockatrice/src/interface/widgets/utility/sequence_edit.cpp
@@ -2,6 +2,7 @@
 
 #include "../../../client/settings/cache_settings.h"
 #include "../../../client/settings/shortcuts_settings.h"
+#include "../../pixel_map_generator.h"
 
 #include <QHBoxLayout>
 #include <QKeyEvent>
@@ -14,8 +15,8 @@ SequenceEdit::SequenceEdit(const QString &_shortcutName, QWidget *parent) : QWid
     defaultButton = new QPushButton("", this);
 
     lineEdit->setMinimumWidth(70);
-    clearButton->setIcon(QPixmap("theme:icons/clearsearch"));
-    defaultButton->setIcon(QPixmap("theme:icons/update"));
+    clearButton->setIcon(themePixmap(QStringLiteral("icons/clearsearch")));
+    defaultButton->setIcon(themePixmap(QStringLiteral("icons/update")));
 
     auto *layout = new QHBoxLayout(this);
     layout->setContentsMargins(0, 0, 0, 0);

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_filter_toolbar_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_filter_toolbar_widget.cpp
@@ -1,5 +1,6 @@
 #include "visual_database_display_filter_toolbar_widget.h"
 
+#include "../../pixel_map_generator.h"
 #include "../deck_editor/card_database_view.h"
 #include "visual_database_display_widget.h"
 
@@ -60,22 +61,22 @@ VisualDatabaseDisplayFilterToolbarWidget::VisualDatabaseDisplayFilterToolbarWidg
     });
 
     quickFilterSaveLoadWidget = new SettingsButtonWidget(this);
-    quickFilterSaveLoadWidget->setButtonIcon(QPixmap("theme:icons/floppy_disk"));
+    quickFilterSaveLoadWidget->setButtonIcon(themePixmap(QStringLiteral("icons/floppy_disk")));
 
     quickFilterNameWidget = new SettingsButtonWidget(this);
-    quickFilterNameWidget->setButtonIcon(QPixmap("theme:icons/pen_to_square"));
+    quickFilterNameWidget->setButtonIcon(themePixmap(QStringLiteral("icons/pen_to_square")));
 
     quickFilterMainTypeWidget = new SettingsButtonWidget(this);
-    quickFilterMainTypeWidget->setButtonIcon(QPixmap("theme:icons/circle_half_stroke"));
+    quickFilterMainTypeWidget->setButtonIcon(themePixmap(QStringLiteral("icons/circle_half_stroke")));
 
     quickFilterSubTypeWidget = new SettingsButtonWidget(this);
-    quickFilterSubTypeWidget->setButtonIcon(QPixmap("theme:icons/dragon"));
+    quickFilterSubTypeWidget->setButtonIcon(themePixmap(QStringLiteral("icons/dragon")));
 
     quickFilterSetWidget = new SettingsButtonWidget(this);
-    quickFilterSetWidget->setButtonIcon(QPixmap("theme:icons/scroll"));
+    quickFilterSetWidget->setButtonIcon(themePixmap(QStringLiteral("icons/scroll")));
 
     quickFilterFormatLegalityWidget = new SettingsButtonWidget(this);
-    quickFilterFormatLegalityWidget->setButtonIcon(QPixmap("theme:icons/scale_balanced"));
+    quickFilterFormatLegalityWidget->setButtonIcon(themePixmap(QStringLiteral("icons/scale_balanced")));
 
     retranslateUi();
 }

--- a/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_database_display/visual_database_display_widget.cpp
@@ -66,7 +66,7 @@ VisualDatabaseDisplayWidget::VisualDatabaseDisplayWidget(QWidget *parent,
     searchEdit->setPlaceholderText(tr("Search by card name (or search expressions)"));
     searchEdit->setClearButtonEnabled(true);
     searchEdit->addAction(loadColorAdjustedPixmap("theme:icons/search"), QLineEdit::LeadingPosition);
-    auto help = searchEdit->addAction(QPixmap("theme:icons/info"), QLineEdit::TrailingPosition);
+    auto help = searchEdit->addAction(themePixmap(QStringLiteral("icons/info")), QLineEdit::TrailingPosition);
     connect(help, &QAction::triggered, this, [this] { createSearchSyntaxHelpWindow(searchEdit); });
 
     setFocusProxy(searchEdit);
@@ -121,7 +121,7 @@ VisualDatabaseDisplayWidget::VisualDatabaseDisplayWidget(QWidget *parent,
 
     clearFilterWidget = new QToolButton();
     clearFilterWidget->setFixedSize(32, 32);
-    clearFilterWidget->setIcon(QPixmap("theme:icons/delete"));
+    clearFilterWidget->setIcon(themePixmap(QStringLiteral("icons/delete")));
     connect(clearFilterWidget, &QToolButton::clicked, this, [this] {
         filterModel->blockSignals(true);
         filterModel->filterTree()->blockSignals(true);

--- a/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_display_options_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_display_options_widget.cpp
@@ -1,5 +1,6 @@
 #include "visual_deck_display_options_widget.h"
 
+#include "../../pixel_map_generator.h"
 #include "../tabs/visual_deck_editor/tab_deck_editor_visual.h"
 
 #include <libcockatrice/utility/qt_utils.h>
@@ -47,7 +48,7 @@ VisualDeckDisplayOptionsWidget::VisualDeckDisplayOptionsWidget(QWidget *parent) 
     sortByLabel = new QLabel(this);
 
     sortCriteriaButton = new SettingsButtonWidget(this);
-    sortCriteriaButton->setButtonIcon(QPixmap("theme:icons/sort_arrow_down"));
+    sortCriteriaButton->setButtonIcon(themePixmap(QStringLiteral("icons/sort_arrow_down")));
 
     sortLabel = new QLabel(sortCriteriaButton);
     sortLabel->setWordWrap(true);
@@ -92,7 +93,7 @@ void VisualDeckDisplayOptionsWidget::retranslateUi()
     sortLabel->setText(tr("Click and drag to change the sort order within the groups"));
     sortCriteriaButton->setToolTip(tr("Configure how cards are sorted within their groups"));
     displayTypeButton->setButtonText(tr("Toggle Layout: Overlap"));
-    displayTypeButton->setButtonIcon(QPixmap("theme:icons/scales"));
+    displayTypeButton->setButtonIcon(themePixmap(QStringLiteral("icons/scales")));
     displayTypeButton->setToolTip(
         tr("Change how cards are displayed within zones (i.e. overlapped or fully visible.)"));
 }
@@ -117,11 +118,11 @@ void VisualDeckDisplayOptionsWidget::updateDisplayType()
     switch (currentDisplayType) {
         case DisplayType::Flat:
             displayTypeButton->setButtonText(tr("Toggle Layout: Flat"));
-            displayTypeButton->setButtonIcon(QPixmap("theme:icons/scroll"));
+            displayTypeButton->setButtonIcon(themePixmap(QStringLiteral("icons/scroll")));
             break;
         case DisplayType::Overlap:
             displayTypeButton->setButtonText(tr("Toggle Layout: Overlap"));
-            displayTypeButton->setButtonIcon(QPixmap("theme:icons/scales"));
+            displayTypeButton->setButtonIcon(themePixmap(QStringLiteral("icons/scales")));
             break;
     }
     emit displayTypeChanged(currentDisplayType);

--- a/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_editor/visual_deck_editor_widget.cpp
@@ -4,6 +4,7 @@
 #include "../../../main.h"
 #include "../../deck_loader/deck_loader.h"
 #include "../../layouts/overlap_layout.h"
+#include "../../pixel_map_generator.h"
 #include "../cards/card_info_picture_with_text_overlay_widget.h"
 #include "../cards/deck_card_zone_display_widget.h"
 #include "../general/layout_containers/flow_widget.h"
@@ -131,7 +132,7 @@ void VisualDeckEditorWidget::initializeSearchBarAndCompleter()
 
     // Search button functionality
     searchPushButton = new CompactPushButton(searchContainer);
-    searchPushButton->setButtonIcon(QPixmap("theme:icons/search"));
+    searchPushButton->setButtonIcon(themePixmap(QStringLiteral("icons/search")));
     connect(searchPushButton, &QPushButton::clicked, this, [=, this]() {
         ExactCard card = CardDatabaseManager::query()->getCard({searchBar->text()});
         if (card) {

--- a/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_search_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_search_widget.cpp
@@ -25,7 +25,7 @@ VisualDeckStorageSearchWidget::VisualDeckStorageSearchWidget(QWidget *parent) : 
     searchBar->setClearButtonEnabled(true);
     searchBar->addAction(loadColorAdjustedPixmap("theme:icons/search"), QLineEdit::LeadingPosition);
 
-    auto help = searchBar->addAction(QPixmap("theme:icons/info"), QLineEdit::TrailingPosition);
+    auto help = searchBar->addAction(themePixmap(QStringLiteral("icons/info")), QLineEdit::TrailingPosition);
     connect(help, &QAction::triggered, this, [this] { createDeckSearchSyntaxHelpWindow(searchBar); });
 
     layout->addWidget(searchBar);

--- a/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
+++ b/cockatrice/src/interface/widgets/visual_deck_storage/visual_deck_storage_widget.cpp
@@ -1,6 +1,7 @@
 #include "visual_deck_storage_widget.h"
 
 #include "../../../client/settings/cache_settings.h"
+#include "../../pixel_map_generator.h"
 #include "../quick_settings/settings_button_widget.h"
 #include "deck_preview/deck_preview_color_identity_filter_widget.h"
 #include "deck_preview/deck_preview_widget.h"
@@ -43,7 +44,7 @@ VisualDeckStorageWidget::VisualDeckStorageWidget(QWidget *parent) : QWidget(pare
     searchWidget = new VisualDeckStorageSearchWidget(this);
 
     refreshButton = new QToolButton(this);
-    refreshButton->setIcon(QPixmap("theme:icons/reload"));
+    refreshButton->setIcon(themePixmap(QStringLiteral("icons/reload")));
     refreshButton->setFixedSize(32, 32);
     connect(refreshButton, &QPushButton::clicked, this, &VisualDeckStorageWidget::refreshIfPossible);
 

--- a/cockatrice/src/interface/window_main.cpp
+++ b/cockatrice/src/interface/window_main.cpp
@@ -44,6 +44,7 @@
 #include "intents/intent_open_server_room_by_name.h"
 #include "intents/url_parser.h"
 #include "logger.h"
+#include "pixel_map_generator.h"
 #include "version_string.h"
 #include "widgets/dialogs/dlg_connect.h"
 #include "widgets/server/handle_public_servers.h"
@@ -271,7 +272,8 @@ void MainWindow::actAbout()
                 GITHUB_TROUBLESHOOTING_URL + "'>" + tr("Troubleshooting") + "</a><br>" + "<a href='" + GITHUB_FAQ_URL +
                 "'>" + tr("F.A.Q.") + "</a><br>"),
         QMessageBox::Ok, this);
-    mb.setIconPixmap(QPixmap("theme:cockatrice").scaled(64, 64, Qt::KeepAspectRatio, Qt::SmoothTransformation));
+    mb.setIconPixmap(
+        themePixmap(QStringLiteral("cockatrice")).scaled(64, 64, Qt::KeepAspectRatio, Qt::SmoothTransformation));
     mb.setTextInteractionFlags(Qt::TextBrowserInteraction);
     mb.exec();
 }
@@ -323,7 +325,7 @@ void MainWindow::retranslateUi()
     aRegister->setText(tr("&Register to server..."));
     aForgotPassword->setText(tr("&Restore password..."));
     aSettings->setText(tr("&Settings..."));
-    aSettings->setIcon(QPixmap("theme:icons/settings"));
+    aSettings->setIcon(themePixmap(QStringLiteral("icons/settings")));
     aExit->setText(tr("&Exit"));
 
 #if defined(__APPLE__) /* For OSX */
@@ -816,7 +818,7 @@ void MainWindow::createTrayIcon()
 
     trayIcon = new QSystemTrayIcon(this);
     trayIcon->setContextMenu(trayIconMenu);
-    trayIcon->setIcon(QPixmap("theme:cockatrice"));
+    trayIcon->setIcon(themePixmap(QStringLiteral("cockatrice")));
     trayIcon->show();
 }
 

--- a/cockatrice/src/main.cpp
+++ b/cockatrice/src/main.cpp
@@ -349,7 +349,7 @@ int main(int argc, char *argv[])
     }
     qCInfo(MainLog) << "MainWindow constructor finished";
 
-    ui.setWindowIcon(QPixmap("theme:cockatrice"));
+    ui.setWindowIcon(themePixmap(QStringLiteral("cockatrice")));
     // set name of the app desktop file; used by wayland to load the window icon
     QGuiApplication::setDesktopFileName("cockatrice");
 


### PR DESCRIPTION
## Short roundup of the initial problem

Loads across the client still use bare `QPixmap("theme:…")`, bypassing the scheme-variant resolution introduced in the previous PR.

## What will change with this Pull Request?

- Migrate the remaining 91 `QPixmap("theme:…")` call sites to `themePixmap()` so icons, replay controls, card fronts/backs and other images resolve to their `-dark`/`-light` variants.
- Stem-exact 1:1 migration; bitmap output for non-variant themes is identical to before.