### PR TITLE
[PictureLoader] Serve cached pictures from the disk cache instead of re-fetching them

### DIFF
--- a/cockatrice/src/interface/card_picture_loader/card_picture_loader_worker.cpp
+++ b/cockatrice/src/interface/card_picture_loader/card_picture_loader_worker.cpp
@@ -84,8 +84,8 @@ void CardPictureLoaderWorker::queueRequest(const QUrl &url, CardPictureLoaderWor
             SettingsCache::instance().cacheStorage().getCardPictureLoaderCacheMethod()) ==
             CardPictureLoaderCacheMethod::CacheMethod::NETWORK_CACHE &&
         cache->metaData(url).isValid()) {
-        // If we hit a cached url, we get to make the request for free, since it won't contribute towards the
-        // rate-limit
+        // A request that will be served from the disk cache never touches the network and therefore
+        // doesn't use up any of the rate limit, so it gets to skip the queue.
         makeRequest(url, worker);
         return;
     }
@@ -107,10 +107,13 @@ QNetworkReply *CardPictureLoaderWorker::makeRequest(const QUrl &url, CardPicture
     req.setHeader(QNetworkRequest::UserAgentHeader, QString("Cockatrice %1").arg(VERSION_STRING));
     req.setRawHeader("Accept", "image/avif,image/webp,image/apng,image/,/*;q=0.8");
 
-    bool useNetworkCache =
-        !picDownload && static_cast<CardPictureLoaderCacheMethod::CacheMethod>(
-                            SettingsCache::instance().cacheStorage().getCardPictureLoaderCacheMethod()) ==
-                            CardPictureLoaderCacheMethod::CacheMethod::NETWORK_CACHE;
+    // Cached entries are served straight from the disk cache even when picture downloads are
+    // enabled: re-fetching an already-cached image would burn the rate limit for nothing. Only a
+    // genuine cache miss goes to the network, and only when downloads are enabled.
+    bool useNetworkCache = static_cast<CardPictureLoaderCacheMethod::CacheMethod>(
+                               SettingsCache::instance().cacheStorage().getCardPictureLoaderCacheMethod()) ==
+                               CardPictureLoaderCacheMethod::CacheMethod::NETWORK_CACHE &&
+                           (cache->metaData(url).isValid() || !picDownload);
 
     req.setAttribute(QNetworkRequest::CacheLoadControlAttribute,
                      useNetworkCache ? QNetworkRequest::AlwaysCache : QNetworkRequest::AlwaysNetwork);


### PR DESCRIPTION
## Short roundup of the initial problem

Cockatrice has a disk cache for card pictures ([QNetworkDiskCache](
https://doc.qt.io/qt-6/qnetworkdiskcache.html)), but as soon as "download
missing pictures" is enabled the cache is ignored: every request goes to the
network with `AlwaysNetwork` and re-fetches images that are sitting in the
local cache, wasting bandwidth and burning the request quota.

## What will change with this Pull Request?

- Serve card pictures from the on-disk network cache whenever the cache
  method is `NETWORK_CACHE` and the image is already present — even when
  picture downloads are enabled.
- Only a genuine cache miss goes to the network, and only when downloads are
  enabled; cached hits are handed out for free via
  [QNetworkRequest::CacheLoadControlAttribute](https://doc.qt.io/qt-6/qnetworkrequest.html#CacheLoadControlAttribute-enum)
  set to `AlwaysCache`.
- Requests that will be served from the disk cache skip the request queue
  entirely ([card_picture_loader_worker.cpp](cockatrice/src/interface/card_picture_loader/card_picture_loader_worker.cpp)),
  so they no longer consume any of the per-second limit and never wait behind
  a slow network fetch.

### Under the hood:

- `makeRequest` now decides `useNetworkCache` from the cache metadata
  (`QNetworkDiskCache::metaData(url).isValid()`) combined with the download
  toggle, instead of only honouring the cache when downloads are globally off.